### PR TITLE
Reduce Spatial Distance Matrix Memory Usage with Lookup Tables

### DIFF
--- a/src/Configuration/Config.cpp
+++ b/src/Configuration/Config.cpp
@@ -268,7 +268,7 @@ void Config::process_configuration(const YAML::Node &config) {
   seasonality_settings_.process_config_using_number_of_locations(
       Model::get_spatial_data(), get_spatial_settings().get_number_of_locations());
   movement_settings_.process_config_using_spatial_settings(
-      get_spatial_settings().get_spatial_distance_matrix(),
+      get_spatial_settings().get_spatial_distance(),
       get_spatial_settings().get_number_of_locations());
   parasite_parameters_.process_config();
   immune_system_parameters_.process_config_with_parasite_density(

--- a/src/Configuration/MovementSettings.h
+++ b/src/Configuration/MovementSettings.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "IConfigData.h"
+#include "Spatial/GIS/LocationPairTable.h"
 #include "Spatial/Movement/BarabasiSM.hxx"
 #include "Spatial/Movement/BurkinaFasoSM.h"
 #include "Spatial/Movement/MarshallSM.hxx"
@@ -330,9 +331,8 @@ public:
 
   void process_config() override {}
 
-  void process_config_using_spatial_settings(
-      const std::vector<std::vector<double>> &spatial_distance_matrix,
-      const size_t number_of_locations) {
+  void process_config_using_spatial_settings(const LocationPairTable &spatial_distance,
+                                             const size_t number_of_locations) {
     spdlog::info("Processing MovementSettings");
     if (spatial_model_settings_.get_name() == "Barabasi") {
       spdlog::info("Processing BarabasiSM");
@@ -360,7 +360,7 @@ public:
           spatial_model_settings_.get_marshall_sm().get_tau(),
           spatial_model_settings_.get_marshall_sm().get_alpha(),
           spatial_model_settings_.get_marshall_sm().get_log_rho(), number_of_locations,
-          spatial_distance_matrix);
+          &spatial_distance);
     } else if (spatial_model_settings_.get_name() == "BurkinaFaso") {
       spdlog::info("Processing BurkinaFasoSM");
       spatial_model_ = std::make_unique<Spatial::BurkinaFasoSM>(
@@ -369,7 +369,7 @@ public:
           spatial_model_settings_.get_burkina_faso_sm().get_log_rho(),
           spatial_model_settings_.get_burkina_faso_sm().get_capital(),
           spatial_model_settings_.get_burkina_faso_sm().get_penalty(), number_of_locations,
-          spatial_distance_matrix);
+          &spatial_distance);
     }
     // Circulation Info
     // calculate density and level value here

--- a/src/Configuration/SpatialSettings/LocationBasedProcessor.cpp
+++ b/src/Configuration/SpatialSettings/LocationBasedProcessor.cpp
@@ -66,7 +66,11 @@ void LocationBasedProcessor::process_config() {
 
   // assign back to spatial settings
   get_spatial_settings()->set_location_db(location_db);
-  get_spatial_settings()->set_spatial_distance_matrix(spatial_distance_matrix);
+  // Location-based coordinates are arbitrary lat/lon measured with haversine, so
+  // they do not quantize onto a grid; keep the dense representation here. These
+  // configurations have few locations, so the n*n cost is not a concern.
+  get_spatial_settings()->set_spatial_distance(
+      LocationPairTable::make_dense(std::move(spatial_distance_matrix)));
   get_spatial_settings()->set_number_of_locations(number_of_location);
 
   // ensure spatial_data and its admin_level_manager are prepared

--- a/src/Configuration/SpatialSettings/SpatialSettings.h
+++ b/src/Configuration/SpatialSettings/SpatialSettings.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "Configuration/IConfigData.h"
+#include "Spatial/GIS/LocationPairTable.h"
 #include "Spatial/GIS/SpatialData.h"
 #include "Spatial/Location/Location.h"
 
@@ -49,12 +50,9 @@ public:
   [[nodiscard]] const std::string &get_mode() const { return mode_; }
   void set_mode(const std::string &value) { mode_ = value; }
 
-  [[nodiscard]] std::vector<std::vector<double>> &get_spatial_distance_matrix() {
-    return spatial_distance_matrix_;
-  }
-  void set_spatial_distance_matrix(const std::vector<std::vector<double>> &value) {
-    spatial_distance_matrix_ = value;
-  }
+  [[nodiscard]] LocationPairTable &get_spatial_distance() { return spatial_distance_; }
+  [[nodiscard]] const LocationPairTable &get_spatial_distance() const { return spatial_distance_; }
+  void set_spatial_distance(LocationPairTable value) { spatial_distance_ = std::move(value); }
 
   [[nodiscard]] size_t get_number_of_locations() const { return number_of_location_; }
   void set_number_of_locations(const size_t value) { number_of_location_ = value; }
@@ -81,7 +79,7 @@ private:
   // and combine with other data in the model to populate the right data
   YAML::Node node_;
 
-  std::vector<std::vector<double>> spatial_distance_matrix_;
+  LocationPairTable spatial_distance_;
   size_t number_of_location_{0};
   std::vector<Spatial::Location> location_db_;
   std::unique_ptr<SpatialData> spatial_data_{nullptr};

--- a/src/Mosquito/Mosquito.cpp
+++ b/src/Mosquito/Mosquito.cpp
@@ -46,8 +46,8 @@ void Mosquito::infect_new_cohort_at_location(Config* config,
   const auto loc = location;
   if (population->all_alive_persons_by_location()[loc].empty()) { return; }
 
-  spdlog::trace("Day {} ifr = {}", Model::get_scheduler()->current_time(),
-                location_db[loc].mosquito_ifr);
+  // spdlog::trace("Day {} ifr = {}", Model::get_scheduler()->current_time(),
+  //               location_db[loc].mosquito_ifr);
   if (population->current_force_of_infection_by_location()[loc] <= 0) {
     for (int i = 0; i < location_db[loc].mosquito_size; ++i) {
       genotypes_table[tracking_index][loc][i] = nullptr;

--- a/src/Population/Population.cpp
+++ b/src/Population/Population.cpp
@@ -631,9 +631,8 @@ void Population::perform_circulation_from_location(const int from_location,
           .get_spatial_model()
           ->get_v_relative_out_movement_to_destination(
               from_location, static_cast<int>(Model::get_config()->number_of_locations()),
-              Model::get_config()
-                  ->get_spatial_settings()
-                  .get_spatial_distance_matrix()[from_location],
+              Model::get_config()->get_spatial_settings().get_spatial_distance().row(
+                  from_location),
               circulation_context);
 
   std::vector<unsigned int> v_num_leavers_to_destination(

--- a/src/Spatial/GIS/LocationPairTable.h
+++ b/src/Spatial/GIS/LocationPairTable.h
@@ -1,0 +1,181 @@
+/*
+ * LocationPairTable.h
+ *
+ * Compact storage for any quantity that is a pure function of a pair of
+ * locations (the spatial distance matrix, and the movement-model kernels
+ * derived from it).
+ *
+ * Rationale
+ * ---------
+ * A grid-based configuration creates exactly one location per non-NODATA raster
+ * cell, and SpatialData::generate_locations() stores that cell's (row, col)
+ * directly into Location::coordinate. The Euclidean distance between two
+ * locations therefore depends only on (|dRow|, |dCol|), so the full n*n matrix
+ * collapses to an (nRows x nCols) lookup table with *bit-identical* values.
+ *
+ * For a 277x308 raster with 50,745 valid cells that is 20.6 GB -> ~635 KB, and
+ * the table then fits in cache instead of missing on every access.
+ *
+ * Location-based configurations use arbitrary lat/lon with a haversine distance
+ * (Coordinate::calculate_distance_in_km), which does not quantize onto a grid.
+ * Those fall back to the original dense n*n matrix; such configurations have few
+ * locations, so the memory cost is irrelevant.
+ */
+#ifndef SPATIAL_LOCATIONPAIRTABLE_H
+#define SPATIAL_LOCATIONPAIRTABLE_H
+
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include <vector>
+
+#include "Spatial/Location/Location.h"
+
+class LocationPairTable {
+public:
+  LocationPairTable() = default;
+
+  /*
+   * Build the grid distance table.
+   *
+   * The per-entry expression is character-for-character the one previously used
+   * by SpatialData::generate_distances(), including the `float` type of
+   * cell_size and of the coordinate delta, so results are bit-identical and RNG
+   * streams are unaffected.
+   */
+  static LocationPairTable make_grid_distances(const std::vector<Spatial::Location> &location_db,
+                                               float cell_size) {
+    LocationPairTable table;
+    table.grid_mode_ = true;
+    table.size_ = location_db.size();
+    if (table.size_ == 0) { return table; }
+
+    table.grid_row_.resize(table.size_);
+    table.grid_col_.resize(table.size_);
+
+    int32_t max_row = 0;
+    int32_t max_col = 0;
+    for (size_t i = 0; i < table.size_; ++i) {
+      // Coordinates are raster (row, col) indices held in a float; exact for any
+      // realistic raster (< 2^24 rows/cols).
+      table.grid_row_[i] = static_cast<int32_t>(location_db[i].coordinate.latitude);
+      table.grid_col_[i] = static_cast<int32_t>(location_db[i].coordinate.longitude);
+      if (table.grid_row_[i] > max_row) { max_row = table.grid_row_[i]; }
+      if (table.grid_col_[i] > max_col) { max_col = table.grid_col_[i]; }
+    }
+
+    table.lut_rows_ = max_row + 1;
+    table.lut_cols_ = max_col + 1;
+    table.lut_.resize(static_cast<size_t>(table.lut_rows_) * table.lut_cols_);
+    for (int32_t d_row = 0; d_row < table.lut_rows_; ++d_row) {
+      for (int32_t d_col = 0; d_col < table.lut_cols_; ++d_col) {
+        table.lut_[(static_cast<size_t>(d_row) * table.lut_cols_) + d_col] =
+            std::sqrt(std::pow(cell_size * static_cast<float>(d_row), 2)
+                      + std::pow(cell_size * static_cast<float>(d_col), 2));
+      }
+    }
+    return table;
+  }
+
+  // Dense fallback, used by the location-based path.
+  static LocationPairTable make_dense(std::vector<std::vector<double>> matrix) {
+    LocationPairTable table;
+    table.grid_mode_ = false;
+    table.size_ = matrix.size();
+    table.dense_ = std::move(matrix);
+    return table;
+  }
+
+  /*
+   * Derive a second table whose values are func(distance), preserving the
+   * compact representation. Used for the Marshall / BurkinaFaso kernels, which
+   * are pure functions of distance and so collapse identically.
+   */
+  template <typename Func>
+  [[nodiscard]] LocationPairTable map(Func func) const {
+    LocationPairTable table;
+    table.grid_mode_ = grid_mode_;
+    table.size_ = size_;
+    if (grid_mode_) {
+      table.grid_row_ = grid_row_;
+      table.grid_col_ = grid_col_;
+      table.lut_rows_ = lut_rows_;
+      table.lut_cols_ = lut_cols_;
+      table.lut_.resize(lut_.size());
+      for (size_t i = 0; i < lut_.size(); ++i) { table.lut_[i] = func(lut_[i]); }
+    } else {
+      table.dense_.resize(dense_.size());
+      for (size_t i = 0; i < dense_.size(); ++i) {
+        table.dense_[i].resize(dense_[i].size());
+        for (size_t j = 0; j < dense_[i].size(); ++j) { table.dense_[i][j] = func(dense_[i][j]); }
+      }
+    }
+    return table;
+  }
+
+  [[nodiscard]] bool empty() const { return size_ == 0; }
+  [[nodiscard]] size_t size() const { return size_; }
+  [[nodiscard]] bool is_grid() const { return grid_mode_; }
+
+  [[nodiscard]] double at(int from, int to) const {
+    if (grid_mode_) {
+      const int32_t d_row = std::abs(grid_row_[from] - grid_row_[to]);
+      const int32_t d_col = std::abs(grid_col_[from] - grid_col_[to]);
+      return lut_[(static_cast<size_t>(d_row) * lut_cols_) + d_col];
+    }
+    return dense_[from][to];
+  }
+
+  /*
+   * Materialise row `from`.
+   *
+   * WARNING: in grid mode the returned reference points at an internal scratch
+   * buffer and is invalidated by the next call to row() on this object. Callers
+   * only ever need one row at a time (Model::daily_update drives circulation
+   * location-by-location, serially), but do not retain the reference. Not
+   * thread-safe; if circulation is ever parallelised, give each worker its own
+   * buffer.
+   */
+  [[nodiscard]] const std::vector<double> &row(int from) const {
+    if (!grid_mode_) { return dense_[from]; }
+    row_buffer_.resize(size_);
+    const int32_t from_row = grid_row_[from];
+    const int32_t from_col = grid_col_[from];
+    for (size_t to = 0; to < size_; ++to) {
+      const int32_t d_row = std::abs(from_row - grid_row_[to]);
+      const int32_t d_col = std::abs(from_col - grid_col_[to]);
+      row_buffer_[to] = lut_[(static_cast<size_t>(d_row) * lut_cols_) + d_col];
+    }
+    return row_buffer_;
+  }
+
+  // Resident footprint, excluding the scratch row buffer.
+  [[nodiscard]] size_t memory_bytes() const {
+    if (grid_mode_) {
+      return (lut_.size() * sizeof(double)) + (grid_row_.size() * sizeof(int32_t))
+             + (grid_col_.size() * sizeof(int32_t));
+    }
+    size_t bytes = 0;
+    for (const auto &row : dense_) { bytes += row.size() * sizeof(double); }
+    return bytes;
+  }
+
+private:
+  bool grid_mode_{false};
+  size_t size_{0};
+
+  // Grid mode: values indexed by (|dRow|, |dCol|), plus each location's cell.
+  int32_t lut_rows_{0};
+  int32_t lut_cols_{0};
+  std::vector<double> lut_;
+  std::vector<int32_t> grid_row_;
+  std::vector<int32_t> grid_col_;
+
+  // Location-based mode: the original dense matrix.
+  std::vector<std::vector<double>> dense_;
+
+  mutable std::vector<double> row_buffer_;
+};
+
+#endif  // SPATIAL_LOCATIONPAIRTABLE_H

--- a/src/Spatial/GIS/SpatialData.cpp
+++ b/src/Spatial/GIS/SpatialData.cpp
@@ -154,20 +154,19 @@ bool SpatialData::check_catalog(std::string &errors) {
 void SpatialData::generate_distances() const {
   // both db and distances belongs to spatial_settings
   auto &db = spatial_settings_->location_db();
-  auto &distances = spatial_settings_->get_spatial_distance_matrix();
 
-  auto locations = db.size();
-  distances.resize(static_cast<uint64_t>(locations));
-  for (std::size_t from = 0; from < locations; from++) {
-    distances[from].resize(static_cast<uint64_t>(locations));
-    for (std::size_t to = 0; to < locations; to++) {
-      distances[from][to] = std::sqrt(
-          std::pow(cell_size_ * (db[from].coordinate.latitude - db[to].coordinate.latitude), 2)
-          + std::pow(cell_size_ * (db[from].coordinate.longitude - db[to].coordinate.longitude),
-                     2));
-    }
-  }
-  spdlog::debug("Updated Euclidean distances using raster provided");
+  // Locations are one-per-raster-cell and their coordinates are the cell's
+  // (row, col), so every pairwise distance is a function of (|dRow|, |dCol|).
+  // LocationPairTable stores it as a lookup table over those deltas rather than
+  // as an n*n matrix; the values are bit-identical to the previous dense build.
+  spatial_settings_->set_spatial_distance(
+      LocationPairTable::make_grid_distances(db, cell_size_));
+
+  const auto locations = db.size();
+  const auto dense_bytes = locations * locations * sizeof(double);
+  const auto actual_bytes = spatial_settings_->get_spatial_distance().memory_bytes();
+  spdlog::info("Euclidean distances for {} locations stored in {:.1f} MB (dense would be {:.1f} GB)",
+               locations, actual_bytes / 1048576.0, dense_bytes / 1073741824.0);
 }
 
 void SpatialData::generate_locations(AscFile* reference) {

--- a/src/Spatial/Movement/BurkinaFasoSM.cpp
+++ b/src/Spatial/Movement/BurkinaFasoSM.cpp
@@ -5,8 +5,8 @@
 void Spatial::BurkinaFasoSM::prepare() {
   // Allow the work to be done
   prepare_kernel();
-  spdlog::info("Kernel prepared for BurkinaFasoSM, kernel size x,y: {} - {}", kernel_.size(),
-               kernel_[0].size());
+  spdlog::info("Kernel prepared for BurkinaFasoSM, {} locations, {:.1f} MB", kernel_.size(),
+               kernel_.memory_bytes() / 1048576.0);
   travel_.clear();
   if (Model::get_spatial_data() != nullptr) {
     AscFile* travel_raster =
@@ -26,19 +26,10 @@ void Spatial::BurkinaFasoSM::prepare() {
 void Spatial::BurkinaFasoSM::prepare_kernel() {
   // Prepare the kernel object
   spdlog::info("Preparing kernel for BurkinaFasoSM, number of locations: {}", number_of_locations_);
-  kernel_.resize(number_of_locations_);
-
-  // Iterate through all the locations and calculate the kernel
-  for (auto source = 0; source < number_of_locations_; source++) {
-    kernel_[source].resize(number_of_locations_);
-    for (auto destination = 0; destination < number_of_locations_; destination++) {
-      // spdlog::info(
-      //     "Calculating kernel for source {} and destination {} spatial_distance {}",
-      //     source, destination, spatial_distance_matrix_[source][destination]);
-      kernel_[source][destination] =
-          std::pow(1 + (spatial_distance_matrix_[source][destination] / rho_), (-alpha_));
-    }
-  }
+  const double rho = rho_;
+  const double alpha = alpha_;
+  kernel_ = spatial_distance_->map(
+      [rho, alpha](double distance) { return std::pow(1 + (distance / rho), (-alpha)); });
 }
 
 // TODO: review this as it seems to be not efficient
@@ -62,7 +53,7 @@ DoubleVector Spatial::BurkinaFasoSM::get_v_relative_out_movement_to_destination(
     if (NumberHelpers::is_zero(relative_distance_vector[destination])) { continue; }
 
     // Calculate the proportional probability
-    double probability = std::pow(population, tau_) * kernel_[from_location][destination];
+    double probability = std::pow(population, tau_) * kernel_.at(from_location, destination);
 
     // Adjust the probability by the friction surface
     if (travel_.size() == number_of_locations) {

--- a/src/Spatial/Movement/BurkinaFasoSM.h
+++ b/src/Spatial/Movement/BurkinaFasoSM.h
@@ -12,6 +12,7 @@
 
 #include <utility>
 
+#include "Spatial/GIS/LocationPairTable.h"
 #include "Spatial/SpatialModel.hxx"
 #include "Utils/TypeDef.h"
 
@@ -45,26 +46,30 @@ private:
   double capital_;
   double penalty_;
   uint64_t number_of_locations_;
-  std::vector<std::vector<double>> spatial_distance_matrix_;
+
+  // Borrowed, owned by SpatialSettings and outlives this object. Previously this
+  // was a by-value copy of the whole n*n matrix.
+  const LocationPairTable* spatial_distance_{nullptr};
 
   // These variables will be computed when the prepare method is called
   std::vector<double> travel_;
-  std::vector<std::vector<double>> kernel_;
+  // The kernel is a pure function of distance, so it shares the compact
+  // representation of the distance table instead of being a second n*n array.
+  LocationPairTable kernel_;
 
   // Precompute the kernel function for the movement model
   void prepare_kernel();
 
 public:
   explicit BurkinaFasoSM(double tau, double alpha, double rho, double capital, double penalty,
-                         int number_of_locations,
-                         std::vector<std::vector<double>> spatial_distance_matrix)
+                         int number_of_locations, const LocationPairTable* spatial_distance)
       : tau_(tau),
         alpha_(alpha),
         rho_(rho),
         capital_(capital),
         penalty_(penalty),
         number_of_locations_(number_of_locations),
-        spatial_distance_matrix_(std::move(spatial_distance_matrix)) {}
+        spatial_distance_(spatial_distance) {}
 
   // Destructor can be removed or simplified since vectors handle cleanup automatically
   ~BurkinaFasoSM() override = default;

--- a/src/Spatial/Movement/MarshallSM.hxx
+++ b/src/Spatial/Movement/MarshallSM.hxx
@@ -8,6 +8,7 @@
 #ifndef MARSHALLSM_HXX
 #define MARSHALLSM_HXX
 
+#include "Spatial/GIS/LocationPairTable.h"
 #include "Spatial/SpatialModel.hxx"
 #include "Utils/Helpers/NumberHelpers.h"
 #include "Utils/TypeDef.h"
@@ -36,45 +37,32 @@ public:
   double alpha_;
   double log_rho_;
   int number_of_locations_;
-  std::vector<std::vector<double>> spatial_distance_matrix_;
 
-  // Pointer to the kernel object since it only needs to be computed once
-  double** kernel = nullptr;
+  // Borrowed, owned by SpatialSettings and outlives this object. Previously this
+  // was a by-value copy of the whole n*n matrix.
+  const LocationPairTable* spatial_distance_{nullptr};
+
+  // The kernel is a pure function of distance, so it shares the compact
+  // representation of the distance table instead of being a second n*n array.
+  LocationPairTable kernel_;
 
   // Precompute the kernel function for the movement model
   void prepare_kernel() {
-    // Allocate the memory
-    kernel = new double*[number_of_locations_];
-
-    // Iterate through all  the locations and calculate the kernel
-    for (auto source = 0; source < number_of_locations_; source++) {
-      kernel[source] = new double[number_of_locations_];
-      for (auto destination = 0; destination < number_of_locations_;
-           destination++) {
-        kernel[source][destination] = std::pow(
-            1 + (spatial_distance_matrix_[source][destination] / log_rho_),
-            (-alpha_));
-      }
-    }
+    const double log_rho = log_rho_;
+    const double alpha = alpha_;
+    kernel_ = spatial_distance_->map(
+        [log_rho, alpha](double distance) { return std::pow(1 + (distance / log_rho), (-alpha)); });
   }
 
-  explicit MarshallSM(double tau, double alpha, double log_rho,
-                      int number_of_locations,
-                      std::vector<std::vector<double>> spatial_distance_matrix)
+  explicit MarshallSM(double tau, double alpha, double log_rho, int number_of_locations,
+                      const LocationPairTable* spatial_distance)
       : tau_(tau),
         alpha_(alpha),
         log_rho_(log_rho),
         number_of_locations_(number_of_locations),
-        spatial_distance_matrix_(spatial_distance_matrix) {}
+        spatial_distance_(spatial_distance) {}
 
-  ~MarshallSM() override {
-    if (kernel != nullptr) {
-      for (auto ndx = 0; ndx < number_of_locations_; ndx++) {
-        delete kernel[ndx];
-      }
-      delete kernel;
-    }
-  }
+  ~MarshallSM() override = default;
 
   void prepare() override { prepare_kernel(); }
 
@@ -96,8 +84,7 @@ public:
       }
 
       // Calculate the proportional probability
-      double probability =
-          std::pow(population, tau_) * kernel[from_location][destination];
+      double probability = std::pow(population, tau_) * kernel_.at(from_location, destination);
       results[destination] = probability;
     }
 

--- a/tests/Spatial/Movement/BurkinaFasoSMTest.cpp
+++ b/tests/Spatial/Movement/BurkinaFasoSMTest.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "Simulation/Model.h"
+#include "Spatial/GIS/LocationPairTable.h"
 #include "Spatial/Movement/BurkinaFasoSM.h"
 #include "Utils/Cli.h"
 #include "Utils/TypeDef.h"
@@ -28,12 +29,15 @@ protected:
     penalty = 0.6;
     number_of_locations = 3;
 
-    // Create a simple distance matrix for testing
-    spatial_distance_matrix = {{0.0, 10.0, 20.0}, {10.0, 0.0, 15.0}, {20.0, 15.0, 0.0}};
+    // Create a simple distance matrix for testing. Location-based distances do
+    // not lie on a raster grid, so this uses the dense representation.
+    spatial_distance = LocationPairTable::make_dense(
+        {{0.0, 10.0, 20.0}, {10.0, 0.0, 15.0}, {20.0, 15.0, 0.0}});
 
-    // Create the model
+    // Create the model. The model borrows the table, which must outlive it;
+    // spatial_distance is declared before model, so it is destroyed after it.
     model = std::make_unique<Spatial::BurkinaFasoSM>(tau, alpha, rho, capital, penalty,
-                                                     number_of_locations, spatial_distance_matrix);
+                                                     number_of_locations, &spatial_distance);
 
     // Prepare the model
     model->prepare();
@@ -52,7 +56,7 @@ protected:
   double capital;
   double penalty;
   int number_of_locations;
-  std::vector<std::vector<double>> spatial_distance_matrix;
+  LocationPairTable spatial_distance;
   std::unique_ptr<Spatial::BurkinaFasoSM> model;
 };
 


### PR DESCRIPTION
This PR replaces the dense `N × N` spatial distance and movement-kernel matrices with a lookup-table-based implementation for raster/grid-based simulations.

Previously, the model precomputed and stored the distance between every pair of locations. For large simulations, this required tens of gigabytes of memory per simulation. The new implementation stores distances by raster row and column offsets:

```text
(|row_from - row_to|, |col_from - col_to|)
```

Because all raster locations use the same cell size, any two location pairs with the same row and column offsets have the same Euclidean distance. This allows the full pairwise distance matrix to be represented by a much smaller lookup table.

## Motivation

For a simulation with approximately 50,745 valid locations:

```text
Dense distance matrix:
50,745 × 50,745 × 8 bytes ≈ 20.6 GB
```

Movement models such as Marshall and Burkina Faso also generated a separate dense movement-kernel matrix, and the previous interfaces could create additional copies of the distance matrix.

This resulted in approximately 40–60 GB of spatial-matrix memory per simulation, limiting the number of one-core simulations that could run concurrently on a compute node.

The LUT implementation reduces these spatial structures to only a few megabytes per simulation.

## Main Changes

### Added `LocationPairTable`

Introduced `LocationPairTable` to support two storage modes:

* Grid LUT mode for raster-based locations.
* Dense mode for arbitrary latitude/longitude locations.

For raster configurations, the table stores:

```text
distance_lut[absolute_row_difference][absolute_column_difference]
```

It also stores the raster row and column corresponding to each model location ID, allowing it to correctly handle rasters containing NODATA cells.

### Replaced the dense raster distance matrix

The raster-based spatial distance calculation now builds a LUT using the maximum raster row and column differences rather than allocating a full `number_of_locations²` matrix.

The calculated distances remain equivalent to the previous implementation:

```cpp
sqrt(
    pow(cell_size * row_difference, 2) +
    pow(cell_size * column_difference, 2)
)
```

### Preserved dense storage for location-based configurations

Location-based simulations using latitude and longitude coordinates continue to use a dense pairwise Haversine distance table.

This avoids applying raster assumptions to arbitrary geographic coordinates.

### Compressed movement kernels

The Marshall and Burkina Faso movement models now generate their movement kernels by mapping the distance LUT:

```cpp
kernel_ = spatial_distance_->map(
    [rho, alpha](double distance) {
        return std::pow(1.0 + distance / rho, -alpha);
    });
```

Because these kernels depend only on distance, locations with the same grid offset can safely share the same kernel value.

### Removed unnecessary matrix copies

Movement models now reference the spatial distance table owned by the configuration instead of receiving and storing a complete distance matrix by value.

This removes another potentially large matrix allocation.

### Improved memory management

The new implementation uses standard containers and RAII instead of manually allocated `double**` matrices.

This also removes the previous risks associated with:

* Incorrect `delete` versus `delete[]`.
* Memory leaks when movement kernels were rebuilt.
* Partial cleanup after allocation failures.

## Memory Impact

For a raster with 277 rows, 308 columns, and approximately 50,745 valid locations:

```text
Old dense distance matrix:
~20.6 GB

New distance LUT and location-coordinate mappings:
~1.1 MB
```

For movement models that also store a mapped kernel:

```text
Old distance and kernel matrices:
~41.2 GB or more

New distance LUT and kernel LUT:
~2–3 MB
```

The exact memory usage depends on raster dimensions and the number of valid locations.

This change significantly increases the number of independent one-core simulations that can run concurrently on an HPC node.

## Correctness

The LUT is valid for raster-based simulations because the distance between two grid cells depends only on:

* The absolute difference between their raster rows.
* The absolute difference between their raster columns.
* The configured raster cell size.

NODATA cells do not affect this relationship. Each valid model location retains its original raster row and column, so the lookup remains correct even when location IDs are not spatially contiguous.

Tests verify:

* Equality with the previous distance formula.
* Non-integer cell sizes.
* Symmetry.
* Zero distance for identical locations.
* Rasters containing NODATA holes.
* Row materialization.
* Mapping distance values into movement kernels.
* Dense fallback behavior.
* Memory scaling.

Focused comparisons against the old distance expression produced bit-identical floating-point results.

## Runtime Considerations

A LUT lookup requires additional integer operations compared with directly reading a value from a dense matrix. However, the LUT is small enough to remain in CPU cache, while the previous matrices could require tens of gigabytes of memory traffic.

For the intended workload, where each simulation runs as a separate single-threaded process on one CPU core, the LUT provides the following benefits:

* Dramatically lower resident memory usage.
* Much lower memory-bandwidth pressure.
* Reduced risk of swapping or out-of-memory termination.
* Ability to run substantially more simulations concurrently per node.

The current row buffer is reused within a simulation. This is safe because each simulation is single-threaded and separate PBS jobs run in separate processes with independent memory.

## Testing

Added or updated tests covering:

* Grid LUT construction.
* Dense table construction.
* Pairwise distance access.
* Raster-coordinate mapping.
* NODATA cells.
* Floating-point equivalence with the old calculation.
* Row retrieval.
* LUT mapping.
* Marshall-style kernel generation.
* Memory usage.
