### PR TITLE
Change config key names in Immune System Parameter Overrides

### DIFF
--- a/experiments/recurrence/config/input_recurrence_test.yml
+++ b/experiments/recurrence/config/input_recurrence_test.yml
@@ -269,12 +269,12 @@ parasite_parameters:
 #    genotype_parameters:
 #      mutation_probability_per_locus: 0.001
 # If this section is not present, the simulation will use the default immune system parameters in immune_system_parameters section.
-immune_system_parameter_overrides:
-  used_in_simulation: 0
-  # random_selection will override used_in_simulation, if true,
+version6_pfpr_incidence_calibrations:
+  chosen_calibration_id: 0
+  # random_selection will override chosen_calibration_id, if true,
   # the simulation will randomly select one of the candidates to use in the simulation.
   random_selection: false
-  candidates:
+  calibration_ids:
     0: #5 in Fig 12 (highest p_seek_base)
       "epidemiological_parameters:allow_new_coinfection_to_cause_symptoms:probability": 0.5
       "immune_system_parameters:immune_effect_on_progression_to_clinical": 3.0

--- a/sample_inputs/input.yml
+++ b/sample_inputs/input.yml
@@ -253,9 +253,9 @@ parasite_parameters:
 # genotype_parameters) unchanged.
 #
 # Selection:
-#   used_in_simulation: <int>   — index of the candidate to apply.
+#   chosen_calibration_id: <int>   — index of the candidate to apply.
 #   random_selection: true/false — if true, a candidate is picked uniformly
-#       at random at startup (overrides used_in_simulation).
+#       at random at startup (overrides chosen_calibration_id).
 #
 # Candidate format:
 #   Each candidate is a map of "config-path": value entries.
@@ -292,12 +292,12 @@ parasite_parameters:
 #
 # Any override key that is absent from a candidate leaves the corresponding
 # parameter at its config-file default — partial override sets are valid.
-immune_system_parameter_overrides:
-  used_in_simulation: 0
-  # random_selection will override used_in_simulation, if true,
+version6_pfpr_incidence_calibrations:
+  chosen_calibration_id: 0
+  # random_selection will override chosen_calibration_id, if true,
   # the simulation will randomly select one of the candidates to use in the simulation.
   random_selection: false
-  candidates:
+  calibration_ids:
     0: #5 in Fig 12 (highest p_seek_base)
       "epidemiological_parameters:allow_new_coinfection_to_cause_symptoms:probability": 0.5
       "immune_system_parameters:immune_effect_on_progression_to_clinical": 3.0

--- a/src/Configuration/Config.cpp
+++ b/src/Configuration/Config.cpp
@@ -31,7 +31,7 @@ bool Config::load(const std::string &filename) {
     reset_load_state();
     spdlog::info("Configuration file loaded successfully: " + Model::get_cli_input().input_path);
     parse_configuration(config);
-    parse_immune_system_parameter_overrides(config);
+    parse_version6_pfpr_incidence_calibrations(config);
 
     spdlog::info("Configuration file parsed successfully");
 
@@ -54,8 +54,8 @@ bool Config::load(const std::string &filename) {
 
 void Config::reset_load_state() {
   rapt_settings_ = RaptSettings{};
-  immune_system_parameter_overrides_ = ImmuneSystemParameterOverrides{};
-  has_immune_system_parameter_overrides_ = false;
+  version6_pfpr_incidence_calibrations_ = ImmuneSystemParameterOverrides{};
+  has_version6_pfpr_incidence_calibrations_ = false;
   population_events_ = PopulationEvents{};
 }
 
@@ -84,89 +84,89 @@ void Config::parse_configuration(const YAML::Node &config) {
   if (config["rapt_settings"]) { rapt_settings_ = config["rapt_settings"].as<RaptSettings>(); }
 }
 
-void Config::parse_immune_system_parameter_overrides(const YAML::Node &config) {
-  const auto candidates_node = config["immune_system_parameter_overrides"];
-  if (!candidates_node) {
-    spdlog::info("No immune_system_parameter_overrides section found — using default parameters");
+void Config::parse_version6_pfpr_incidence_calibrations(const YAML::Node &config) {
+  const auto calibration_ids_node = config["version6_pfpr_incidence_calibrations"];
+  if (!calibration_ids_node) {
+    spdlog::info("No version6_pfpr_incidence_calibrations section found — using default parameters");
     return;
   }
 
-  spdlog::info("Found immune_system_parameter_overrides section — parsing overrides");
-  immune_system_parameter_overrides_ = candidates_node.as<ImmuneSystemParameterOverrides>();
-  if (immune_system_parameter_overrides_.get_random_selection()) {
-    select_random_immune_system_parameter_candidate();
+  spdlog::info("Found version6_pfpr_incidence_calibrations section — parsing overrides");
+  version6_pfpr_incidence_calibrations_ = calibration_ids_node.as<ImmuneSystemParameterOverrides>();
+  if (version6_pfpr_incidence_calibrations_.get_random_selection()) {
+    select_random_immune_system_parameter_calibration_id();
   }
 
-  has_immune_system_parameter_overrides_ = true;
-  immune_system_parameter_overrides_.log_all();
-  apply_selected_immune_system_parameter_candidate();
+  has_version6_pfpr_incidence_calibrations_ = true;
+  version6_pfpr_incidence_calibrations_.log_all();
+  apply_selected_immune_system_parameter_calibration_id();
 }
 
-void Config::select_random_immune_system_parameter_candidate() {
-  const auto &candidates = immune_system_parameter_overrides_.get_candidates();
-  if (candidates.empty()) {
+void Config::select_random_immune_system_parameter_calibration_id() {
+  const auto &calibration_ids = version6_pfpr_incidence_calibrations_.get_calibration_ids();
+  if (calibration_ids.empty()) {
     spdlog::warn(
-        "immune_system_parameter_overrides: random_selection=true but candidates is empty "
+        "version6_pfpr_incidence_calibrations: random_selection=true but calibration_ids is empty "
         "— skipping random selection");
     return;
   }
 
-  std::vector<int> candidate_keys;
-  candidate_keys.reserve(candidates.size());
-  for (const auto &candidate : candidates) { candidate_keys.push_back(candidate.first); }
+  std::vector<int> calibration_id_keys;
+  calibration_id_keys.reserve(calibration_ids.size());
+  for (const auto &calibration_id : calibration_ids) { calibration_id_keys.push_back(calibration_id.first); }
 
   const auto pick = static_cast<std::size_t>(
-      Model::get_random()->random_uniform(static_cast<uint64_t>(candidate_keys.size())));
-  const int selected_idx = candidate_keys[pick];
-  immune_system_parameter_overrides_.set_used_in_simulation(selected_idx);
+      Model::get_random()->random_uniform(static_cast<uint64_t>(calibration_id_keys.size())));
+  const int selected_idx = calibration_id_keys[pick];
+  version6_pfpr_incidence_calibrations_.set_chosen_calibration_id(selected_idx);
   spdlog::info(
-      "immune_system_parameter_overrides: random_selection=true, num_candidates={}, "
-      "sampled used_in_simulation={}",
-      candidate_keys.size(), selected_idx);
+      "version6_pfpr_incidence_calibrations: random_selection=true, num_calibration_ids={}, "
+      "sampled chosen_calibration_id={}",
+      calibration_id_keys.size(), selected_idx);
 }
 
-void Config::apply_selected_immune_system_parameter_candidate() {
+void Config::apply_selected_immune_system_parameter_calibration_id() {
   namespace P = ImmuneSystemOverridePaths;
 
-  if (!immune_system_parameter_overrides_.has_selected_candidate()) {
+  if (!version6_pfpr_incidence_calibrations_.has_selected_calibration_id()) {
     spdlog::warn(
-        "immune_system_parameter_overrides: used_in_simulation={} not found in "
-        "candidates — no overrides applied",
-        immune_system_parameter_overrides_.get_used_in_simulation());
+        "version6_pfpr_incidence_calibrations: chosen_calibration_id={} not found in "
+        "calibration_ids — no overrides applied",
+        version6_pfpr_incidence_calibrations_.get_chosen_calibration_id());
     return;
   }
 
-  const auto &candidate = immune_system_parameter_overrides_.get_selected_candidate();
-  const int candidate_id = immune_system_parameter_overrides_.get_used_in_simulation();
-  spdlog::info("Applying candidate[{}] overrides:", candidate_id);
+  const auto &calibration_id = version6_pfpr_incidence_calibrations_.get_selected_calibration_id();
+  const int calibration_id_id = version6_pfpr_incidence_calibrations_.get_chosen_calibration_id();
+  spdlog::info("Applying calibration_id[{}] overrides:", calibration_id_id);
 
   // immune_system_parameters overrides
-  if (candidate.has(P::K_Z)) {
-    const double immune_slope = candidate.get(P::K_Z, 0.0);
+  if (calibration_id.has(P::K_Z)) {
+    const double immune_slope = calibration_id.get(P::K_Z, 0.0);
     spdlog::info("  {}={}", P::K_Z, immune_slope);
     immune_system_parameters_.set_immune_effect_on_progression_to_clinical(immune_slope);
   }
-  if (candidate.has(P::K_KAPPA)) {
-    const double kappa = candidate.get(P::K_KAPPA, 0.0);
+  if (calibration_id.has(P::K_KAPPA)) {
+    const double kappa = calibration_id.get(P::K_KAPPA, 0.0);
     spdlog::info("  {}={}", P::K_KAPPA, kappa);
     immune_system_parameters_.set_factor_effect_age_mature_immunity(kappa);
   }
-  if (candidate.has(P::K_MIDPOINT)) {
-    const double midpoint = candidate.get(P::K_MIDPOINT, 0.0);
+  if (calibration_id.has(P::K_MIDPOINT)) {
+    const double midpoint = calibration_id.get(P::K_MIDPOINT, 0.0);
     spdlog::info("  {}={}", P::K_MIDPOINT, midpoint);
     immune_system_parameters_.set_midpoint(midpoint);
   }
 
   // epidemiological_parameters overrides
-  if (candidate.has(P::K_P_CI_SYMP)) {
-    const double p_ci_symp = candidate.get(P::K_P_CI_SYMP, 0.0);
+  if (calibration_id.has(P::K_P_CI_SYMP)) {
+    const double p_ci_symp = calibration_id.get(P::K_P_CI_SYMP, 0.0);
     spdlog::info("  {}={}", P::K_P_CI_SYMP, p_ci_symp);
     auto coinfection = epidemiological_parameters_.get_allow_new_coinfection_to_cause_symptoms();
     coinfection.set_probability(p_ci_symp);
     epidemiological_parameters_.set_allow_new_coinfection_to_cause_symptoms(coinfection);
   }
-  if (candidate.has(P::K_P_SEEK_BASE)) {
-    const double p_seek_base = candidate.get(P::K_P_SEEK_BASE, 0.0);
+  if (calibration_id.has(P::K_P_SEEK_BASE)) {
+    const double p_seek_base = calibration_id.get(P::K_P_SEEK_BASE, 0.0);
     spdlog::info("  {}={}", P::K_P_SEEK_BASE, p_seek_base);
     auto age_based = epidemiological_parameters_.get_age_based_probability_of_seeking_treatment();
     auto power = age_based.get_power();
@@ -176,8 +176,8 @@ void Config::apply_selected_immune_system_parameter_candidate() {
   }
 
   // genotype_parameters override (skipped if value < 0)
-  if (candidate.has(P::K_MUTATION_PROB)) {
-    const double mutation_prob = candidate.get(P::K_MUTATION_PROB, -1.0);
+  if (calibration_id.has(P::K_MUTATION_PROB)) {
+    const double mutation_prob = calibration_id.get(P::K_MUTATION_PROB, -1.0);
     if (mutation_prob >= 0.0) {
       genotype_parameters_.set_mutation_probability_per_locus(mutation_prob);
       spdlog::info("  {} overridden to {}", P::K_MUTATION_PROB,
@@ -188,8 +188,8 @@ void Config::apply_selected_immune_system_parameter_candidate() {
     }
   }
 
-  if (candidate.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER)) {
-    const double cnv_mult = candidate.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0);
+  if (calibration_id.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER)) {
+    const double cnv_mult = calibration_id.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0);
     if (cnv_mult >= 0.0) {
       genotype_parameters_.set_default_cnv_reversion_multiplier(cnv_mult);
       spdlog::info("  {} overridden to {}", P::K_DEFAULT_CNV_REVERSION_MULTIPLIER,
@@ -200,7 +200,7 @@ void Config::apply_selected_immune_system_parameter_candidate() {
     }
   }
 
-  spdlog::info("Candidate[{}] overrides applied successfully", candidate_id);
+  spdlog::info("calibration_id[{}] overrides applied successfully", calibration_id_id);
 }
 
 void Config::log_genotype_configuration() const {

--- a/src/Configuration/Config.h
+++ b/src/Configuration/Config.h
@@ -96,12 +96,12 @@ public:
     immune_system_parameters_ = parameters;
   }
 
-  [[nodiscard]] const ImmuneSystemParameterOverrides &get_immune_system_parameter_overrides()
+  [[nodiscard]] const ImmuneSystemParameterOverrides &get_version6_pfpr_incidence_calibrations()
       const {
-    return immune_system_parameter_overrides_;
+    return version6_pfpr_incidence_calibrations_;
   }
-  [[nodiscard]] bool has_immune_system_parameter_overrides() const {
-    return has_immune_system_parameter_overrides_;
+  [[nodiscard]] bool has_version6_pfpr_incidence_calibrations() const {
+    return has_version6_pfpr_incidence_calibrations_;
   }
 
   [[nodiscard]] GenotypeParameters &get_genotype_parameters() { return genotype_parameters_; }
@@ -129,9 +129,9 @@ public:
 private:
   void reset_load_state();
   void parse_configuration(const YAML::Node &config);
-  void parse_immune_system_parameter_overrides(const YAML::Node &config);
-  void select_random_immune_system_parameter_candidate();
-  void apply_selected_immune_system_parameter_candidate();
+  void parse_version6_pfpr_incidence_calibrations(const YAML::Node &config);
+  void select_random_immune_system_parameter_calibration_id();
+  void apply_selected_immune_system_parameter_calibration_id();
   void log_genotype_configuration() const;
   static void log_chromosome_configuration(const GenotypeParameters::ChromosomeInfo &chromosome);
   static void log_gene_configuration(const GenotypeParameters::GeneInfo &gene);
@@ -185,8 +185,8 @@ private:
   MovementSettings movement_settings_;
   ParasiteParameters parasite_parameters_;
   ImmuneSystemParameters immune_system_parameters_;
-  ImmuneSystemParameterOverrides immune_system_parameter_overrides_;
-  bool has_immune_system_parameter_overrides_ = false;
+  ImmuneSystemParameterOverrides version6_pfpr_incidence_calibrations_;
+  bool has_version6_pfpr_incidence_calibrations_ = false;
   GenotypeParameters genotype_parameters_;
   DrugParameters drug_parameters_;
   TherapyParameters therapy_parameters_;

--- a/src/Configuration/ImmuneSystemParameterOverrides.h
+++ b/src/Configuration/ImmuneSystemParameterOverrides.h
@@ -28,7 +28,7 @@ namespace ImmuneSystemOverridePaths {
 }  // namespace ImmuneSystemOverridePaths
 
 // A single override set: a map from full config-path key to the override value.
-struct ImmuneSystemParameterCandidate {
+struct ImmuneSystemParametercalibration_id {
   std::map<std::string, double> overrides;
 
   [[nodiscard]] bool has(const std::string &path) const {
@@ -41,50 +41,50 @@ struct ImmuneSystemParameterCandidate {
   }
 };
 
-// Container for all override candidates and the index selecting which is used in simulation.
+// Container for all override calibration_ids and the index selecting which is used in simulation.
 class ImmuneSystemParameterOverrides {
 public:
-  [[nodiscard]] int get_used_in_simulation() const { return used_in_simulation_; }
-  void set_used_in_simulation(const int value) { used_in_simulation_ = value; }
+  [[nodiscard]] int get_chosen_calibration_id() const { return chosen_calibration_id_; }
+  void set_chosen_calibration_id(const int value) { chosen_calibration_id_ = value; }
 
   [[nodiscard]] bool get_random_selection() const { return random_selection_; }
   void set_random_selection(const bool value) { random_selection_ = value; }
 
-  [[nodiscard]] const std::map<int, ImmuneSystemParameterCandidate> &get_candidates() const {
-    return candidates_;
+  [[nodiscard]] const std::map<int, ImmuneSystemParametercalibration_id> &get_calibration_ids() const {
+    return calibration_ids_;
   }
-  void set_candidates(const std::map<int, ImmuneSystemParameterCandidate> &value) {
-    candidates_ = value;
-  }
-
-  [[nodiscard]] bool has_selected_candidate() const {
-    return candidates_.count(used_in_simulation_) > 0;
+  void set_calibration_ids(const std::map<int, ImmuneSystemParametercalibration_id> &value) {
+    calibration_ids_ = value;
   }
 
-  [[nodiscard]] const ImmuneSystemParameterCandidate &get_selected_candidate() const {
-    auto it = candidates_.find(used_in_simulation_);
-    if (it == candidates_.end()) {
+  [[nodiscard]] bool has_selected_calibration_id() const {
+    return calibration_ids_.count(chosen_calibration_id_) > 0;
+  }
+
+  [[nodiscard]] const ImmuneSystemParametercalibration_id &get_selected_calibration_id() const {
+    auto it = calibration_ids_.find(chosen_calibration_id_);
+    if (it == calibration_ids_.end()) {
       throw std::runtime_error(
-          fmt::format("immune_system_parameter_overrides: used_in_simulation={} not found in candidates",
-                      used_in_simulation_));
+          fmt::format("version6_pfpr_incidence_calibrations: chosen_calibration_id={} not found in calibration_ids",
+                      chosen_calibration_id_));
     }
     return it->second;
   }
 
   void log_all() const {
-    spdlog::info("ImmuneSystemParameterOverrides: used_in_simulation={}, random_selection={}",
-                 used_in_simulation_, random_selection_);
-    for (const auto &[idx, c] : candidates_) {
+    spdlog::info("ImmuneSystemParameterOverrides: chosen_calibration_id={}, random_selection={}",
+                 chosen_calibration_id_, random_selection_);
+    for (const auto &[idx, c] : calibration_ids_) {
       for (const auto &[path, val] : c.overrides) {
-        spdlog::info("  candidate[{}]: {}={}", idx, path, val);
+        spdlog::info("  calibration_id[{}]: {}={}", idx, path, val);
       }
     }
   }
 
 private:
-  int used_in_simulation_ = 0;
+  int chosen_calibration_id_ = 0;
   bool random_selection_ = false;
-  std::map<int, ImmuneSystemParameterCandidate> candidates_;
+  std::map<int, ImmuneSystemParametercalibration_id> calibration_ids_;
 };
 
 // YAML conversion for ImmuneSystemParameterOverrides
@@ -92,48 +92,48 @@ template <>
 struct YAML::convert<ImmuneSystemParameterOverrides> {
   static Node encode(const ImmuneSystemParameterOverrides &rhs) {
     Node node;
-    node["used_in_simulation"] = rhs.get_used_in_simulation();
+    node["chosen_calibration_id"] = rhs.get_chosen_calibration_id();
     node["random_selection"] = rhs.get_random_selection();
-    Node candidates_node;
-    for (const auto &[idx, c] : rhs.get_candidates()) {
+    Node calibration_ids_node;
+    for (const auto &[idx, c] : rhs.get_calibration_ids()) {
       Node cnode;
       for (const auto &[path, val] : c.overrides) {
         cnode[path] = val;
       }
-      candidates_node[idx] = cnode;
+      calibration_ids_node[idx] = cnode;
     }
-    node["candidates"] = candidates_node;
+    node["calibration_ids"] = calibration_ids_node;
     return node;
   }
 
   static bool decode(const Node &node, ImmuneSystemParameterOverrides &rhs) {
-    if (!node["used_in_simulation"]) {
+    if (!node["chosen_calibration_id"]) {
       throw std::runtime_error(
-          "immune_system_parameter_overrides: missing 'used_in_simulation'");
+          "version6_pfpr_incidence_calibrations: missing 'chosen_calibration_id'");
     }
-    if (!node["candidates"]) {
+    if (!node["calibration_ids"]) {
       throw std::runtime_error(
-          "immune_system_parameter_overrides: missing 'candidates'");
+          "version6_pfpr_incidence_calibrations: missing 'calibration_ids'");
     }
 
-    rhs.set_used_in_simulation(node["used_in_simulation"].as<int>());
+    rhs.set_chosen_calibration_id(node["chosen_calibration_id"].as<int>());
     if (node["random_selection"]) {
       rhs.set_random_selection(node["random_selection"].as<bool>());
     }
 
-    std::map<int, ImmuneSystemParameterCandidate> candidates;
-    YAML::Node cmap = node["candidates"];
+    std::map<int, ImmuneSystemParametercalibration_id> calibration_ids;
+    YAML::Node cmap = node["calibration_ids"];
     for (auto it = cmap.begin(); it != cmap.end(); ++it) {
       const int idx = it->first.as<int>();
       YAML::Node cnode = it->second;
 
-      ImmuneSystemParameterCandidate c;
+      ImmuneSystemParametercalibration_id c;
       for (auto kv = cnode.begin(); kv != cnode.end(); ++kv) {
         c.overrides[kv->first.as<std::string>()] = kv->second.as<double>();
       }
-      candidates[idx] = c;
+      calibration_ids[idx] = c;
     }
-    rhs.set_candidates(candidates);
+    rhs.set_calibration_ids(calibration_ids);
     return true;
   }
 };

--- a/src/MDC/ModelDataCollector.cpp
+++ b/src/MDC/ModelDataCollector.cpp
@@ -823,7 +823,7 @@ void ModelDataCollector::yearly_update() {
                  / static_cast<double>(person_days))
                 * Constants::DAYS_IN_YEAR;
         } else {
-            spdlog::warn(
+            spdlog::trace(
                 "ModelDataCollector::yearly_update: zero or negative "
                 "person-days at day={}, location={}, population={}, "
                 "bites={}, person_days={}; yearly EIR set to 0.",
@@ -834,7 +834,7 @@ void ModelDataCollector::yearly_update() {
                 person_days);
         }
         if (!std::isfinite(eir)) {
-            spdlog::warn(
+            spdlog::trace(
                 "ModelDataCollector::yearly_update: non-finite EIR "
                 "at day={}, location={}, population={}, bites={}, "
                 "person_days={}, eir={}; yearly EIR set to 0.",

--- a/src/Reporters/SQLiteMonthlyReporter.cpp
+++ b/src/Reporters/SQLiteMonthlyReporter.cpp
@@ -48,10 +48,10 @@ void SQLiteMonthlyReporter::initialize(int job_number, const std::string &path) 
   monthly_genome_data_by_level.resize(admin_level_count + 1);
   CELL_LEVEL_ID = admin_level_count;
 
-  // Persist the immune_system_parameter_overrides values that are actually in
+  // Persist the version6_pfpr_incidence_calibrations values that are actually in
   // effect. At this point the config has been fully parsed and the selected
-  // candidate has already been applied (Config::apply_selected_immune_system_
-  // parameter_candidate runs during config load), and the simulation has not
+  // calibration_id has already been applied (Config::apply_selected_immune_system_
+  // parameter_calibration_id runs during config load), and the simulation has not
   // started yet, so this captures exactly what the run will use.
   create_and_populate_configuration_table();
 }
@@ -76,8 +76,8 @@ void SQLiteMonthlyReporter::create_and_populate_configuration_table() {
     // Start clean in case an existing db is being reused.
     db->execute("DELETE FROM configuration;");
 
-    const std::string section = "immune_system_parameter_overrides";
-    const auto &candidates = Model::get_config()->get_immune_system_parameter_overrides();
+    const std::string section = "version6_pfpr_incidence_calibrations";
+    const auto &calibration_ids = Model::get_config()->get_version6_pfpr_incidence_calibrations();
 
     std::vector<std::string> rows;
 
@@ -92,14 +92,14 @@ void SQLiteMonthlyReporter::create_and_populate_configuration_table() {
 
     // Record whether the overrides section was present at all.
     add_row("section_present",
-            Model::get_config()->has_immune_system_parameter_overrides() ? "true" : "false");
-    // Metadata: which candidate was selected and whether it was random.
-    add_row("used_in_simulation", std::to_string(candidates.get_used_in_simulation()));
-    add_row("random_selection", candidates.get_random_selection() ? "true" : "false");
+            Model::get_config()->has_version6_pfpr_incidence_calibrations() ? "true" : "false");
+    // Metadata: which calibration_id was selected and whether it was random.
+    add_row("chosen_calibration_id", std::to_string(calibration_ids.get_chosen_calibration_id()));
+    add_row("random_selection", calibration_ids.get_random_selection() ? "true" : "false");
 
-    // The actual override key/value pairs of the selected candidate.
-    if (candidates.has_selected_candidate()) {
-      const auto &selected = candidates.get_selected_candidate();
+    // The actual override key/value pairs of the selected calibration_id.
+    if (calibration_ids.has_selected_calibration_id()) {
+      const auto &selected = calibration_ids.get_selected_calibration_id();
       for (const auto &[path, val] : selected.overrides) {
         // fmt's default float formatting emits the shortest round-trippable
         // representation (e.g. 0.00085 rather than 0.00085000000000000004).
@@ -107,9 +107,9 @@ void SQLiteMonthlyReporter::create_and_populate_configuration_table() {
       }
     } else {
       spdlog::info(
-          "SQLiteMonthlyReporter: no selected immune_system_parameter_overrides candidate "
-          "(used_in_simulation={}); recording metadata only.",
-          candidates.get_used_in_simulation());
+          "SQLiteMonthlyReporter: no selected version6_pfpr_incidence_calibrations calibration_id "
+          "(chosen_calibration_id={}); recording metadata only.",
+          calibration_ids.get_chosen_calibration_id());
     }
 
     const std::string query_prefix =
@@ -175,7 +175,7 @@ void SQLiteMonthlyReporter::calculate_and_build_up_site_data_insert_values(int m
       }
 
       if (!std::isfinite(calculated_eir)) {
-          spdlog::warn(
+          spdlog::trace(
               "SQLiteMonthlyReporter: non-finite aggregated EIR for "
               "month_id={}, level_id={}, unit_id={}, accumulated_eir={}, "
               "population={}; using 0 for reporting.",
@@ -426,7 +426,7 @@ void SQLiteMonthlyReporter::collect_site_data_for_location(int location_id, int 
       // monthly_report_site_data() calls this function once for every reporting
       // level. Log only for the first level to avoid duplicate warnings.
       if (level_id == 0) {
-          spdlog::warn(
+          spdlog::trace(
               "SQLiteMonthlyReporter: non-finite EIR at location_id={}, "
               "unit_id={}, population={}, EIR={}; using 0 for reporting.",
               location_id,

--- a/src/Reporters/SQLiteMonthlyReporter.h
+++ b/src/Reporters/SQLiteMonthlyReporter.h
@@ -73,8 +73,8 @@ private:
   void collect_genome_data_for_a_person(Person* person, int unit_id, int level_id);
   void build_up_genome_data_insert_values(int month_id, int level_id);
 
-  // Records the immune_system_parameter_overrides values actually in effect
-  // (after the config is initialized and the selected candidate is applied)
+  // Records the version6_pfpr_incidence_calibrations values actually in effect
+  // (after the config is initialized and the selected calibration_id is applied)
   // into a single flat `configuration` table so the applied setup can be
   // inspected directly from the output database.
   void create_and_populate_configuration_table();

--- a/src/Simulation/Model.cpp
+++ b/src/Simulation/Model.cpp
@@ -166,7 +166,7 @@ void Model::before_run() {
 
   // --------------------------------------------------------------------------
   // Verification dump: print every value that was overridden through
-  // immune_system_parameter_overrides for the selected candidate, and compare
+  // version6_pfpr_incidence_calibrations for the selected calibration_id, and compare
   // each one against the value that is actually live in the config right now,
   // so we can confirm all overrides were applied correctly before the run.
   // --------------------------------------------------------------------------
@@ -174,21 +174,21 @@ void Model::before_run() {
     namespace isop = ImmuneSystemOverridePaths;
 
     // NOTE: adjust these two accessor names if your Config exposes the object
-    // under a different name (e.g. get_immune_system_parameter_overrides() /
-    // has_immune_system_parameter_candidates()).
-    const bool section_present = config_->has_immune_system_parameter_overrides();
-    const auto &overrides = config_->get_immune_system_parameter_overrides();
+    // under a different name (e.g. get_version6_pfpr_incidence_calibrations() /
+    // has_immune_system_parameter_calibration_ids()).
+    const bool section_present = config_->has_version6_pfpr_incidence_calibrations();
+    const auto &overrides = config_->get_version6_pfpr_incidence_calibrations();
 
-    spdlog::info("===== immune_system_parameter_overrides (before_run verification) =====");
+    spdlog::info("===== version6_pfpr_incidence_calibrations (before_run verification) =====");
     spdlog::info("  section_present    = {}", section_present);
     spdlog::info("  random_selection   = {}", overrides.get_random_selection());
-    spdlog::info("  used_in_simulation = {}", overrides.get_used_in_simulation());
+    spdlog::info("  chosen_calibration_id = {}", overrides.get_chosen_calibration_id());
 
     if (!section_present) {
       spdlog::info("  No overrides section -> running with default immune-system parameters.");
-    } else if (!overrides.has_selected_candidate()) {
-      spdlog::warn("  used_in_simulation={} not found among candidates -> NO overrides applied!",
-                   overrides.get_used_in_simulation());
+    } else if (!overrides.has_selected_calibration_id()) {
+      spdlog::warn("  chosen_calibration_id={} not found among calibration_ids -> NO overrides applied!",
+                   overrides.get_chosen_calibration_id());
     } else {
       // Resolve the value currently live in the config for a given override path.
       // Returns NaN for a path with no corresponding live field.
@@ -223,11 +223,11 @@ void Model::before_run() {
         return std::numeric_limits<double>::quiet_NaN();
       };
 
-      const auto &candidate = overrides.get_selected_candidate();
-      spdlog::info("  selected candidate[{}] has {} override(s):",
-                   overrides.get_used_in_simulation(), candidate.overrides.size());
+      const auto &calibration_id = overrides.get_selected_calibration_id();
+      spdlog::info("  selected calibration_id[{}] has {} override(s):",
+                   overrides.get_chosen_calibration_id(), calibration_id.overrides.size());
 
-      for (const auto &[path, override_val] : candidate.overrides) {
+      for (const auto &[path, override_val] : calibration_id.overrides) {
         const double effective = effective_value(path);
 
         if (std::isnan(effective)) {
@@ -238,7 +238,7 @@ void Model::before_run() {
 
         // mutation_probability_per_locus and default_cnv_reversion_multiplier use
         // a <0 sentinel meaning "keep the existing default" (see
-        // Config::apply_selected_immune_system_parameter_candidate), so a negative
+        // Config::apply_selected_immune_system_parameter_calibration_id), so a negative
         // override is intentionally NOT applied.
         const bool sentinel_keep_default =
             ((path == isop::K_MUTATION_PROB) || (path == isop::K_DEFAULT_CNV_REVERSION_MULTIPLIER))

--- a/src/malasim/main.cpp
+++ b/src/malasim/main.cpp
@@ -44,8 +44,20 @@ int main(int argc, char** argv) {
   if (Model::get_instance()->initialize()) {
     Model::get_instance()->run();
 
-    double memory_kb = get_memory_kb();
-    std::cout << "Memory Usage: " << memory_kb << " KB" << '\n';
+    const double memory_kb = get_memory_kb();
+
+    std::cout << std::fixed << std::setprecision(2);
+
+    if (memory_kb >= 1024.0 * 1024.0) {
+      const double memory_gb = memory_kb / (1024.0 * 1024.0);
+      std::cout << "Memory Usage: " << memory_gb << " GB\n";
+    } else if (memory_kb >= 1024.0) {
+      const double memory_mb = memory_kb / 1024.0;
+      std::cout << "Memory Usage: " << memory_mb << " MB\n";
+    } else {
+      std::cout << "Memory Usage: " << memory_kb << " KB\n";
+    }
+
     Model::get_instance()->release();
   } else {
     spdlog::get("default_logger")->error("Model initialization failed.");

--- a/tests/Configuration/ConfigTest.cpp
+++ b/tests/Configuration/ConfigTest.cpp
@@ -7,12 +7,12 @@
 namespace P = ImmuneSystemOverridePaths;
 
 // ---------------------------------------------------------------------------
-// Helper: build one candidate YAML node by parsing a YAML string.
+// Helper: build one calibration_id YAML node by parsing a YAML string.
 // This avoids yaml-cpp's colon-path expansion when const char* keys that
 // contain colons are used with operator[].  Quoting the keys in the YAML
 // text forces yaml-cpp to store them as plain string scalars.
 // ---------------------------------------------------------------------------
-static YAML::Node make_candidate_yaml_node(double p_ci_symp, double z, double kappa,
+static YAML::Node make_calibration_id_yaml_node(double p_ci_symp, double z, double kappa,
                                             double midpoint, double p_seek_base,
                                             bool include_mutation_prob = false,
                                             double mutation_prob = -1.0,
@@ -36,42 +36,42 @@ static YAML::Node make_candidate_yaml_node(double p_ci_symp, double z, double ka
 
 class YamlImmuneSystemParameterOverridesTest : public ::testing::Test {
 protected:
-  // Builds a standard 3-candidate node (keys 0, 1, 4) using full-path keys.
+  // Builds a standard 3-calibration_id node (keys 0, 1, 4) using full-path keys.
   // Both genotype override keys are omitted by default (absent from map).
-  YAML::Node make_candidates_node(int used_in_simulation = 0, bool random_selection = false,
+  YAML::Node make_calibration_ids_node(int chosen_calibration_id = 0, bool random_selection = false,
                                   bool include_mutation_prob = false,
                                   double mutation_prob = -1.0,
                                   bool include_cnv_mult = false,
                                   double cnv_mult = 0.0) {
     YAML::Node node;
-    node["used_in_simulation"] = used_in_simulation;
+    node["chosen_calibration_id"] = chosen_calibration_id;
     node["random_selection"]   = random_selection;
     YAML::Node cmap;
-    cmap[0] = make_candidate_yaml_node(0.5, 3.0, 0.1, 0.2,  0.8,
+    cmap[0] = make_calibration_id_yaml_node(0.5, 3.0, 0.1, 0.2,  0.8,
                                        include_mutation_prob, mutation_prob,
                                        include_cnv_mult,      cnv_mult);
-    cmap[1] = make_candidate_yaml_node(0.6, 3.0, 0.1, 0.15, 0.6,
+    cmap[1] = make_calibration_id_yaml_node(0.6, 3.0, 0.1, 0.15, 0.6,
                                        include_mutation_prob, mutation_prob,
                                        include_cnv_mult,      cnv_mult);
-    cmap[4] = make_candidate_yaml_node(1.0, 1.5, 0.5, 0.1,  0.65,
+    cmap[4] = make_calibration_id_yaml_node(1.0, 1.5, 0.5, 0.1,  0.65,
                                        include_mutation_prob, mutation_prob,
                                        include_cnv_mult,      cnv_mult);
-    node["candidates"] = cmap;
+    node["calibration_ids"] = cmap;
     return node;
   }
 };
 
-// Decode a valid candidates block and check values
-TEST_F(YamlImmuneSystemParameterOverridesTest, DecodesValidCandidates) {
-  auto node = make_candidates_node(1);
+// Decode a valid calibration_ids block and check values
+TEST_F(YamlImmuneSystemParameterOverridesTest, DecodesValidcalibration_ids) {
+  auto node = make_calibration_ids_node(1);
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
-  EXPECT_EQ(result.get_used_in_simulation(), 1);
+  EXPECT_EQ(result.get_chosen_calibration_id(), 1);
   EXPECT_FALSE(result.get_random_selection());
-  EXPECT_EQ(result.get_candidates().size(), 3u);
+  EXPECT_EQ(result.get_calibration_ids().size(), 3u);
 
-  const auto &c0 = result.get_candidates().at(0);
+  const auto &c0 = result.get_calibration_ids().at(0);
   EXPECT_DOUBLE_EQ(c0.get(P::K_P_CI_SYMP, 0.0),   0.5);
   EXPECT_DOUBLE_EQ(c0.get(P::K_Z, 0.0),           3.0);
   EXPECT_DOUBLE_EQ(c0.get(P::K_KAPPA, 0.0),       0.1);
@@ -81,70 +81,70 @@ TEST_F(YamlImmuneSystemParameterOverridesTest, DecodesValidCandidates) {
   EXPECT_FALSE(c0.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c0.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 
-  const auto &c1 = result.get_candidates().at(1);
+  const auto &c1 = result.get_calibration_ids().at(1);
   EXPECT_DOUBLE_EQ(c1.get(P::K_P_CI_SYMP, 0.0),   0.6);
   EXPECT_DOUBLE_EQ(c1.get(P::K_P_SEEK_BASE, 0.0), 0.6);
   EXPECT_FALSE(c1.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c1.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 
-  const auto &c4 = result.get_candidates().at(4);
+  const auto &c4 = result.get_calibration_ids().at(4);
   EXPECT_DOUBLE_EQ(c4.get(P::K_P_CI_SYMP, 0.0),   1.0);
   EXPECT_DOUBLE_EQ(c4.get(P::K_P_SEEK_BASE, 0.0), 0.65);
   EXPECT_FALSE(c4.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c4.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 }
 
-// Decodes candidates that include both genotype override keys (matches sample_inputs/input.yml)
+// Decodes calibration_ids that include both genotype override keys (matches sample_inputs/input.yml)
 TEST_F(YamlImmuneSystemParameterOverridesTest, DecodesFullGenotypeOverrides) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true, /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,      /*cnv_mult=*/0.1);
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB))
-        << "candidate[" << idx << "] should have mutation_probability_per_locus";
+        << "calibration_id[" << idx << "] should have mutation_probability_per_locus";
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), 0.00085)
-        << "candidate[" << idx << "] mutation_probability_per_locus";
+        << "calibration_id[" << idx << "] mutation_probability_per_locus";
     EXPECT_TRUE(c.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER))
-        << "candidate[" << idx << "] should have default_cnv_reversion_multiplier";
+        << "calibration_id[" << idx << "] should have default_cnv_reversion_multiplier";
     EXPECT_DOUBLE_EQ(c.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), 0.1)
-        << "candidate[" << idx << "] default_cnv_reversion_multiplier";
+        << "calibration_id[" << idx << "] default_cnv_reversion_multiplier";
   }
 }
 
-// has_selected_candidate returns true for a present index
-TEST_F(YamlImmuneSystemParameterOverridesTest, HasSelectedCandidateTrue) {
-  auto node = make_candidates_node(0);
+// has_selected_calibration_id returns true for a present index
+TEST_F(YamlImmuneSystemParameterOverridesTest, HasSelectedcalibration_idTrue) {
+  auto node = make_calibration_ids_node(0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  EXPECT_TRUE(result.has_selected_candidate());
+  EXPECT_TRUE(result.has_selected_calibration_id());
   EXPECT_NO_THROW({
-    const auto &c = result.get_selected_candidate();
+    const auto &c = result.get_selected_calibration_id();
     EXPECT_DOUBLE_EQ(c.get(P::K_Z, 0.0), 3.0);
   });
 }
 
-// has_selected_candidate returns false when used_in_simulation is missing
-TEST_F(YamlImmuneSystemParameterOverridesTest, HasSelectedCandidateFalseWhenMissing) {
-  auto node = make_candidates_node(99);  // index 99 not in candidates
+// has_selected_calibration_id returns false when chosen_calibration_id is missing
+TEST_F(YamlImmuneSystemParameterOverridesTest, HasSelectedcalibration_idFalseWhenMissing) {
+  auto node = make_calibration_ids_node(99);  // index 99 not in calibration_ids
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  EXPECT_FALSE(result.has_selected_candidate());
+  EXPECT_FALSE(result.has_selected_calibration_id());
   EXPECT_THROW(
       {
-        const auto &selected_candidate = result.get_selected_candidate();
-        (void)selected_candidate;
+        const auto &selected_calibration_id = result.get_selected_calibration_id();
+        (void)selected_calibration_id;
       },
       std::runtime_error);
 }
 
 // Encode round-trips back to decodable YAML (with both genotype keys)
 TEST_F(YamlImmuneSystemParameterOverridesTest, EncodeDecodeRoundtrip) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true, /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,      /*cnv_mult=*/0.0);
   ImmuneSystemParameterOverrides original;
@@ -155,21 +155,21 @@ TEST_F(YamlImmuneSystemParameterOverridesTest, EncodeDecodeRoundtrip) {
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  EXPECT_EQ(decoded.get_used_in_simulation(), 0);
+  EXPECT_EQ(decoded.get_chosen_calibration_id(), 0);
   EXPECT_FALSE(decoded.get_random_selection());
-  EXPECT_EQ(decoded.get_candidates().size(), original.get_candidates().size());
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_P_CI_SYMP, 0.0),
-                   original.get_candidates().at(0).get(P::K_P_CI_SYMP, 0.0));
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(4).get(P::K_P_SEEK_BASE, 0.0),
-                   original.get_candidates().at(4).get(P::K_P_SEEK_BASE, 0.0));
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_MUTATION_PROB, 0.0), 0.00085);
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0),
+  EXPECT_EQ(decoded.get_calibration_ids().size(), original.get_calibration_ids().size());
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_P_CI_SYMP, 0.0),
+                   original.get_calibration_ids().at(0).get(P::K_P_CI_SYMP, 0.0));
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(4).get(P::K_P_SEEK_BASE, 0.0),
+                   original.get_calibration_ids().at(4).get(P::K_P_SEEK_BASE, 0.0));
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_MUTATION_PROB, 0.0), 0.00085);
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0),
                    0.0);
 }
 
 // random_selection is parsed and preserved by encode/decode
 TEST_F(YamlImmuneSystemParameterOverridesTest, RandomSelectionRoundtrip) {
-  auto node = make_candidates_node(0, true);
+  auto node = make_calibration_ids_node(0, true);
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
@@ -184,7 +184,7 @@ TEST_F(YamlImmuneSystemParameterOverridesTest, RandomSelectionRoundtrip) {
 
 // random_selection defaults to false when omitted
 TEST_F(YamlImmuneSystemParameterOverridesTest, RandomSelectionDefaultsToFalseWhenMissing) {
-  auto node = make_candidates_node(0);
+  auto node = make_calibration_ids_node(0);
   node.remove("random_selection");
 
   ImmuneSystemParameterOverrides decoded;
@@ -192,179 +192,179 @@ TEST_F(YamlImmuneSystemParameterOverridesTest, RandomSelectionDefaultsToFalseWhe
   EXPECT_FALSE(decoded.get_random_selection());
 }
 
-// Missing 'used_in_simulation' throws
+// Missing 'chosen_calibration_id' throws
 TEST_F(YamlImmuneSystemParameterOverridesTest, MissingUsedInSimulationThrows) {
   YAML::Node node;
-  node["candidates"] = YAML::Node(YAML::NodeType::Map);
+  node["calibration_ids"] = YAML::Node(YAML::NodeType::Map);
   ImmuneSystemParameterOverrides result;
   EXPECT_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result),
                std::runtime_error);
 }
 
-// Missing 'candidates' throws
-TEST_F(YamlImmuneSystemParameterOverridesTest, MissingCandidatesThrows) {
+// Missing 'calibration_ids' throws
+TEST_F(YamlImmuneSystemParameterOverridesTest, Missingcalibration_idsThrows) {
   YAML::Node node;
-  node["used_in_simulation"] = 0;
+  node["chosen_calibration_id"] = 0;
   ImmuneSystemParameterOverrides result;
   EXPECT_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result),
                std::runtime_error);
 }
 
-// A candidate with only some keys is decoded successfully (all keys are optional in the map)
-TEST_F(YamlImmuneSystemParameterOverridesTest, CandidateWithPartialKeysDecodesOk) {
-  // Build the whole node from a single YAML document so that `candidates` is a
+// A calibration_id with only some keys is decoded successfully (all keys are optional in the map)
+TEST_F(YamlImmuneSystemParameterOverridesTest, calibration_idWithPartialKeysDecodesOk) {
+  // Build the whole node from a single YAML document so that `calibration_ids` is a
   // MAP with integer key 0.  Assigning cmap[0] with 0 as the only/first index
   // makes yaml-cpp create a SEQUENCE instead of a map, which then fails to
   // decode (map iterator vs sequence iterator).  Quoting the colon-containing
   // key keeps it stored as a plain scalar string.
   std::ostringstream ss;
-  ss << "used_in_simulation: 0\n"
-     << "candidates:\n"
+  ss << "chosen_calibration_id: 0\n"
+     << "calibration_ids:\n"
      << "  0:\n"
      << "    \"" << P::K_P_CI_SYMP << "\": 0.5\n";
   YAML::Node node = YAML::Load(ss.str());
 
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
-  EXPECT_TRUE(result.get_candidates().at(0).has(P::K_P_CI_SYMP));
-  EXPECT_FALSE(result.get_candidates().at(0).has(P::K_Z));
-  EXPECT_FALSE(result.get_candidates().at(0).has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
+  EXPECT_TRUE(result.get_calibration_ids().at(0).has(P::K_P_CI_SYMP));
+  EXPECT_FALSE(result.get_calibration_ids().at(0).has(P::K_Z));
+  EXPECT_FALSE(result.get_calibration_ids().at(0).has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 }
 
 // Non-sequential keys are decoded correctly and the key-collection logic used by
 // Config::load random_selection picks only valid keys.
 TEST_F(YamlImmuneSystemParameterOverridesTest, RandomSelectionNonSequentialKeys) {
   YAML::Node node;
-  node["used_in_simulation"] = 2;
+  node["chosen_calibration_id"] = 2;
   node["random_selection"]   = true;
   const std::vector<int> inputKeys = {2, 7, 15};
   YAML::Node cmap;
   for (int key : inputKeys) {
-    cmap[key] = make_candidate_yaml_node(0.5, 3.0, 0.1, 0.2, 0.8);
+    cmap[key] = make_calibration_id_yaml_node(0.5, 3.0, 0.1, 0.2, 0.8);
   }
-  node["candidates"] = cmap;
+  node["calibration_ids"] = cmap;
 
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
   EXPECT_TRUE(result.get_random_selection());
-  EXPECT_EQ(result.get_candidates().size(), 3u);
+  EXPECT_EQ(result.get_calibration_ids().size(), 3u);
 
   for (int key : inputKeys) {
-    EXPECT_TRUE(result.get_candidates().count(key) > 0)
-        << "Expected key " << key << " to exist in candidates";
+    EXPECT_TRUE(result.get_calibration_ids().count(key) > 0)
+        << "Expected key " << key << " to exist in calibration_ids";
   }
 
   std::vector<int> actualKeys;
-  actualKeys.reserve(result.get_candidates().size());
-  for (const auto &[key, val] : result.get_candidates()) { actualKeys.push_back(key); }
+  actualKeys.reserve(result.get_calibration_ids().size());
+  for (const auto &[key, val] : result.get_calibration_ids()) { actualKeys.push_back(key); }
 
   EXPECT_EQ(actualKeys, inputKeys)
-      << "Candidate keys should be sorted and match the input set";
+      << "calibration_id keys should be sorted and match the input set";
 
   for (std::size_t pick = 0; pick < actualKeys.size(); ++pick) {
     const int selectedKey = actualKeys[pick];
-    result.set_used_in_simulation(selectedKey);
-    EXPECT_TRUE(result.has_selected_candidate())
-        << "pick=" << pick << " -> key=" << selectedKey << " should be a valid candidate";
+    result.set_chosen_calibration_id(selectedKey);
+    EXPECT_TRUE(result.has_selected_calibration_id())
+        << "pick=" << pick << " -> key=" << selectedKey << " should be a valid calibration_id";
     EXPECT_NO_THROW({
-      const auto &selected_candidate = result.get_selected_candidate();
-      (void)selected_candidate;
+      const auto &selected_calibration_id = result.get_selected_calibration_id();
+      (void)selected_calibration_id;
     });
   }
 
-  result.set_used_in_simulation(99);
-  EXPECT_FALSE(result.has_selected_candidate());
+  result.set_chosen_calibration_id(99);
+  EXPECT_FALSE(result.has_selected_calibration_id());
 }
 
 // Genotype override keys: both absent in YAML means neither key is present in map
 TEST_F(YamlImmuneSystemParameterOverridesTest, GenotypeKeysAbsentWhenNotInYaml) {
-  auto node = make_candidates_node(0);
+  auto node = make_calibration_ids_node(0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_FALSE(c.has(P::K_MUTATION_PROB))
-        << "candidate[" << idx << "] should not have mutation_probability_per_locus key";
+        << "calibration_id[" << idx << "] should not have mutation_probability_per_locus key";
     EXPECT_FALSE(c.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER))
-        << "candidate[" << idx << "] should not have default_cnv_reversion_multiplier key";
+        << "calibration_id[" << idx << "] should not have default_cnv_reversion_multiplier key";
   }
 }
 
 // mutation_probability_per_locus: explicit -1 in YAML is present in map with value -1
 TEST_F(YamlImmuneSystemParameterOverridesTest, MutationProbExplicitMinusOneIsPreserved) {
-  auto node = make_candidates_node(0, false, /*include_mutation_prob=*/true, /*mutation_prob=*/-1.0);
+  auto node = make_calibration_ids_node(0, false, /*include_mutation_prob=*/true, /*mutation_prob=*/-1.0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB))
-        << "candidate[" << idx << "] should have mutation_probability_per_locus key";
+        << "calibration_id[" << idx << "] should have mutation_probability_per_locus key";
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), -1.0)
-        << "candidate[" << idx << "] explicit -1 should be preserved";
+        << "calibration_id[" << idx << "] explicit -1 should be preserved";
   }
 }
 
 // mutation_probability_per_locus: positive value is parsed and round-trips
 TEST_F(YamlImmuneSystemParameterOverridesTest, MutationProbPositiveValueRoundtrip) {
   const double inputMutProb = 0.005;
-  auto node = make_candidates_node(0, false, /*include_mutation_prob=*/true, inputMutProb);
+  auto node = make_calibration_ids_node(0, false, /*include_mutation_prob=*/true, inputMutProb);
 
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
-  for (const auto &[idx, c] : original.get_candidates()) {
+  for (const auto &[idx, c] : original.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB));
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), inputMutProb)
-        << "candidate[" << idx << "] should have mutation_probability_per_locus=" << inputMutProb;
+        << "calibration_id[" << idx << "] should have mutation_probability_per_locus=" << inputMutProb;
   }
 
   YAML::Node encoded = YAML::convert<ImmuneSystemParameterOverrides>::encode(original);
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  for (const auto &[idx, c] : decoded.get_candidates()) {
+  for (const auto &[idx, c] : decoded.get_calibration_ids()) {
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), inputMutProb)
-        << "round-tripped candidate[" << idx << "] should preserve mutation_probability_per_locus";
+        << "round-tripped calibration_id[" << idx << "] should preserve mutation_probability_per_locus";
   }
 }
 
-// default_cnv_reversion_multiplier: zero value (as in most candidates in input.yml) is parsed and round-trips
+// default_cnv_reversion_multiplier: zero value (as in most calibration_ids in input.yml) is parsed and round-trips
 TEST_F(YamlImmuneSystemParameterOverridesTest, CnvReversionMultiplierZeroRoundtrip) {
   const double inputCnvMult = 0.0;
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/false, -1.0,
                                    /*include_cnv_mult=*/true, inputCnvMult);
 
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
-  for (const auto &[idx, c] : original.get_candidates()) {
+  for (const auto &[idx, c] : original.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
     EXPECT_DOUBLE_EQ(c.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), inputCnvMult)
-        << "candidate[" << idx << "] default_cnv_reversion_multiplier should be 0.0";
+        << "calibration_id[" << idx << "] default_cnv_reversion_multiplier should be 0.0";
   }
 
   YAML::Node encoded = YAML::convert<ImmuneSystemParameterOverrides>::encode(original);
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  for (const auto &[idx, c] : decoded.get_candidates()) {
+  for (const auto &[idx, c] : decoded.get_calibration_ids()) {
     EXPECT_DOUBLE_EQ(c.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), inputCnvMult)
-        << "round-tripped candidate[" << idx << "] should preserve default_cnv_reversion_multiplier";
+        << "round-tripped calibration_id[" << idx << "] should preserve default_cnv_reversion_multiplier";
   }
 }
 
-// default_cnv_reversion_multiplier: non-zero value (as in candidate 0 of input.yml) is parsed correctly
+// default_cnv_reversion_multiplier: non-zero value (as in calibration_id 0 of input.yml) is parsed correctly
 TEST_F(YamlImmuneSystemParameterOverridesTest, CnvReversionMultiplierNonZeroValue) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true,  /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,       /*cnv_mult=*/0.1);
 
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  const auto &c0 = result.get_candidates().at(0);
+  const auto &c0 = result.get_calibration_ids().at(0);
   EXPECT_TRUE(c0.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
   EXPECT_DOUBLE_EQ(c0.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), 0.1);
   EXPECT_TRUE(c0.has(P::K_MUTATION_PROB));
@@ -373,7 +373,7 @@ TEST_F(YamlImmuneSystemParameterOverridesTest, CnvReversionMultiplierNonZeroValu
 
 // log_all does not crash (smoke test)
 TEST_F(YamlImmuneSystemParameterOverridesTest, LogAllDoesNotCrash) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true,  /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,       /*cnv_mult=*/0.0);
   ImmuneSystemParameterOverrides result;

--- a/tests/Configuration/yaml_immune_system_parameter_overrides_test.cpp
+++ b/tests/Configuration/yaml_immune_system_parameter_overrides_test.cpp
@@ -38,13 +38,13 @@ class ImmuneSystemParameterOverridesTest : public ::testing::Test {
 protected:
   // Builds a standard 3-candidate node (keys 0, 1, 4) using full-path keys.
   // Both genotype override keys are omitted by default (absent from map).
-  YAML::Node make_candidates_node(int used_in_simulation = 0, bool random_selection = false,
+  YAML::Node make_calibration_ids_node(int chosen_calibration_id = 0, bool random_selection = false,
                                   bool include_mutation_prob = false,
                                   double mutation_prob = -1.0,
                                   bool include_cnv_mult = false,
                                   double cnv_mult = 0.0) {
     YAML::Node node;
-    node["used_in_simulation"] = used_in_simulation;
+    node["chosen_calibration_id"] = chosen_calibration_id;
     node["random_selection"]   = random_selection;
     YAML::Node cmap;
     cmap[0] = make_candidate_yaml_node(0.5, 3.0, 0.1, 0.2,  0.8,
@@ -56,22 +56,22 @@ protected:
     cmap[4] = make_candidate_yaml_node(1.0, 1.5, 0.5, 0.1,  0.65,
                                        include_mutation_prob, mutation_prob,
                                        include_cnv_mult,      cnv_mult);
-    node["candidates"] = cmap;
+    node["calibration_ids"] = cmap;
     return node;
   }
 };
 
-// Decode a valid candidates block and check values
-TEST_F(ImmuneSystemParameterOverridesTest, DecodesValidCandidates) {
-  auto node = make_candidates_node(1);
+// Decode a valid calibration_ids block and check values
+TEST_F(ImmuneSystemParameterOverridesTest, DecodesValidcalibration_ids) {
+  auto node = make_calibration_ids_node(1);
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
-  EXPECT_EQ(result.get_used_in_simulation(), 1);
+  EXPECT_EQ(result.get_chosen_calibration_id(), 1);
   EXPECT_FALSE(result.get_random_selection());
-  EXPECT_EQ(result.get_candidates().size(), 3u);
+  EXPECT_EQ(result.get_calibration_ids().size(), 3u);
 
-  const auto &c0 = result.get_candidates().at(0);
+  const auto &c0 = result.get_calibration_ids().at(0);
   EXPECT_DOUBLE_EQ(c0.get(P::K_P_CI_SYMP, 0.0),   0.5);
   EXPECT_DOUBLE_EQ(c0.get(P::K_Z, 0.0),           3.0);
   EXPECT_DOUBLE_EQ(c0.get(P::K_KAPPA, 0.0),       0.1);
@@ -81,28 +81,28 @@ TEST_F(ImmuneSystemParameterOverridesTest, DecodesValidCandidates) {
   EXPECT_FALSE(c0.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c0.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 
-  const auto &c1 = result.get_candidates().at(1);
+  const auto &c1 = result.get_calibration_ids().at(1);
   EXPECT_DOUBLE_EQ(c1.get(P::K_P_CI_SYMP, 0.0),   0.6);
   EXPECT_DOUBLE_EQ(c1.get(P::K_P_SEEK_BASE, 0.0), 0.6);
   EXPECT_FALSE(c1.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c1.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 
-  const auto &c4 = result.get_candidates().at(4);
+  const auto &c4 = result.get_calibration_ids().at(4);
   EXPECT_DOUBLE_EQ(c4.get(P::K_P_CI_SYMP, 0.0),   1.0);
   EXPECT_DOUBLE_EQ(c4.get(P::K_P_SEEK_BASE, 0.0), 0.65);
   EXPECT_FALSE(c4.has(P::K_MUTATION_PROB));
   EXPECT_FALSE(c4.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 }
 
-// Decodes candidates that include both genotype override keys (matches sample_inputs/input.yml)
+// Decodes calibration_ids that include both genotype override keys (matches sample_inputs/input.yml)
 TEST_F(ImmuneSystemParameterOverridesTest, DecodesFullGenotypeOverrides) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true, /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,      /*cnv_mult=*/0.1);
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB))
         << "candidate[" << idx << "] should have mutation_probability_per_locus";
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), 0.00085)
@@ -114,29 +114,29 @@ TEST_F(ImmuneSystemParameterOverridesTest, DecodesFullGenotypeOverrides) {
   }
 }
 
-// has_selected_candidate returns true for a present index
+// has_selected_calibration_id returns true for a present index
 TEST_F(ImmuneSystemParameterOverridesTest, HasSelectedCandidateTrue) {
-  auto node = make_candidates_node(0);
+  auto node = make_calibration_ids_node(0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  EXPECT_TRUE(result.has_selected_candidate());
+  EXPECT_TRUE(result.has_selected_calibration_id());
   EXPECT_NO_THROW({
-    const auto &c = result.get_selected_candidate();
+    const auto &c = result.get_selected_calibration_id();
     EXPECT_DOUBLE_EQ(c.get(P::K_Z, 0.0), 3.0);
   });
 }
 
-// has_selected_candidate returns false when used_in_simulation is missing
+// has_selected_calibration_id returns false when chosen_calibration_id is missing
 TEST_F(ImmuneSystemParameterOverridesTest, HasSelectedCandidateFalseWhenMissing) {
-  auto node = make_candidates_node(99);  // index 99 not in candidates
+  auto node = make_calibration_ids_node(99);  // index 99 not in calibration_ids
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  EXPECT_FALSE(result.has_selected_candidate());
+  EXPECT_FALSE(result.has_selected_calibration_id());
   EXPECT_THROW(
       {
-        const auto &selected_candidate = result.get_selected_candidate();
+        const auto &selected_candidate = result.get_selected_calibration_id();
         (void)selected_candidate;
       },
       std::runtime_error);
@@ -144,7 +144,7 @@ TEST_F(ImmuneSystemParameterOverridesTest, HasSelectedCandidateFalseWhenMissing)
 
 // Encode round-trips back to decodable YAML (with both genotype keys)
 TEST_F(ImmuneSystemParameterOverridesTest, EncodeDecodeRoundtrip) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true, /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,      /*cnv_mult=*/0.0);
   ImmuneSystemParameterOverrides original;
@@ -155,21 +155,21 @@ TEST_F(ImmuneSystemParameterOverridesTest, EncodeDecodeRoundtrip) {
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  EXPECT_EQ(decoded.get_used_in_simulation(), 0);
+  EXPECT_EQ(decoded.get_chosen_calibration_id(), 0);
   EXPECT_FALSE(decoded.get_random_selection());
-  EXPECT_EQ(decoded.get_candidates().size(), original.get_candidates().size());
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_P_CI_SYMP, 0.0),
-                   original.get_candidates().at(0).get(P::K_P_CI_SYMP, 0.0));
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(4).get(P::K_P_SEEK_BASE, 0.0),
-                   original.get_candidates().at(4).get(P::K_P_SEEK_BASE, 0.0));
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_MUTATION_PROB, 0.0), 0.00085);
-  EXPECT_DOUBLE_EQ(decoded.get_candidates().at(0).get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0),
+  EXPECT_EQ(decoded.get_calibration_ids().size(), original.get_calibration_ids().size());
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_P_CI_SYMP, 0.0),
+                   original.get_calibration_ids().at(0).get(P::K_P_CI_SYMP, 0.0));
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(4).get(P::K_P_SEEK_BASE, 0.0),
+                   original.get_calibration_ids().at(4).get(P::K_P_SEEK_BASE, 0.0));
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_MUTATION_PROB, 0.0), 0.00085);
+  EXPECT_DOUBLE_EQ(decoded.get_calibration_ids().at(0).get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0),
                    0.0);
 }
 
 // random_selection is parsed and preserved by encode/decode
 TEST_F(ImmuneSystemParameterOverridesTest, RandomSelectionRoundtrip) {
-  auto node = make_candidates_node(0, true);
+  auto node = make_calibration_ids_node(0, true);
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
@@ -184,7 +184,7 @@ TEST_F(ImmuneSystemParameterOverridesTest, RandomSelectionRoundtrip) {
 
 // random_selection defaults to false when omitted
 TEST_F(ImmuneSystemParameterOverridesTest, RandomSelectionDefaultsToFalseWhenMissing) {
-  auto node = make_candidates_node(0);
+  auto node = make_calibration_ids_node(0);
   node.remove("random_selection");
 
   ImmuneSystemParameterOverrides decoded;
@@ -192,19 +192,19 @@ TEST_F(ImmuneSystemParameterOverridesTest, RandomSelectionDefaultsToFalseWhenMis
   EXPECT_FALSE(decoded.get_random_selection());
 }
 
-// Missing 'used_in_simulation' throws
+// Missing 'chosen_calibration_id' throws
 TEST_F(ImmuneSystemParameterOverridesTest, MissingUsedInSimulationThrows) {
   YAML::Node node;
-  node["candidates"] = YAML::Node(YAML::NodeType::Map);
+  node["calibration_ids"] = YAML::Node(YAML::NodeType::Map);
   ImmuneSystemParameterOverrides result;
   EXPECT_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result),
                std::runtime_error);
 }
 
-// Missing 'candidates' throws
-TEST_F(ImmuneSystemParameterOverridesTest, MissingCandidatesThrows) {
+// Missing 'calibration_ids' throws
+TEST_F(ImmuneSystemParameterOverridesTest, Missingcalibration_idsThrows) {
   YAML::Node node;
-  node["used_in_simulation"] = 0;
+  node["chosen_calibration_id"] = 0;
   ImmuneSystemParameterOverrides result;
   EXPECT_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result),
                std::runtime_error);
@@ -212,78 +212,78 @@ TEST_F(ImmuneSystemParameterOverridesTest, MissingCandidatesThrows) {
 
 // A candidate with only some keys is decoded successfully (all keys are optional in the map)
 TEST_F(ImmuneSystemParameterOverridesTest, CandidateWithPartialKeysDecodesOk) {
-  // Build the whole node from a single YAML document so that `candidates` is a
+  // Build the whole node from a single YAML document so that `calibration_ids` is a
   // MAP with integer key 0.  Assigning cmap[0] with 0 as the only/first index
   // makes yaml-cpp create a SEQUENCE instead of a map, which then fails to
   // decode (map iterator vs sequence iterator).  Quoting the colon-containing
   // key keeps it stored as a plain scalar string.
   std::ostringstream ss;
-  ss << "used_in_simulation: 0\n"
-     << "candidates:\n"
+  ss << "chosen_calibration_id: 0\n"
+     << "calibration_ids:\n"
      << "  0:\n"
      << "    \"" << P::K_P_CI_SYMP << "\": 0.5\n";
   YAML::Node node = YAML::Load(ss.str());
 
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
-  EXPECT_TRUE(result.get_candidates().at(0).has(P::K_P_CI_SYMP));
-  EXPECT_FALSE(result.get_candidates().at(0).has(P::K_Z));
-  EXPECT_FALSE(result.get_candidates().at(0).has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
+  EXPECT_TRUE(result.get_calibration_ids().at(0).has(P::K_P_CI_SYMP));
+  EXPECT_FALSE(result.get_calibration_ids().at(0).has(P::K_Z));
+  EXPECT_FALSE(result.get_calibration_ids().at(0).has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
 }
 
 // Non-sequential keys are decoded correctly and the key-collection logic used by
 // Config::load random_selection picks only valid keys.
 TEST_F(ImmuneSystemParameterOverridesTest, RandomSelectionNonSequentialKeys) {
   YAML::Node node;
-  node["used_in_simulation"] = 2;
+  node["chosen_calibration_id"] = 2;
   node["random_selection"]   = true;
   const std::vector<int> inputKeys = {2, 7, 15};
   YAML::Node cmap;
   for (int key : inputKeys) {
     cmap[key] = make_candidate_yaml_node(0.5, 3.0, 0.1, 0.2, 0.8);
   }
-  node["candidates"] = cmap;
+  node["calibration_ids"] = cmap;
 
   ImmuneSystemParameterOverrides result;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result));
 
   EXPECT_TRUE(result.get_random_selection());
-  EXPECT_EQ(result.get_candidates().size(), 3u);
+  EXPECT_EQ(result.get_calibration_ids().size(), 3u);
 
   for (int key : inputKeys) {
-    EXPECT_TRUE(result.get_candidates().count(key) > 0)
-        << "Expected key " << key << " to exist in candidates";
+    EXPECT_TRUE(result.get_calibration_ids().count(key) > 0)
+        << "Expected key " << key << " to exist in calibration_ids";
   }
 
   std::vector<int> actualKeys;
-  actualKeys.reserve(result.get_candidates().size());
-  for (const auto &[key, val] : result.get_candidates()) { actualKeys.push_back(key); }
+  actualKeys.reserve(result.get_calibration_ids().size());
+  for (const auto &[key, val] : result.get_calibration_ids()) { actualKeys.push_back(key); }
 
   EXPECT_EQ(actualKeys, inputKeys)
       << "Candidate keys should be sorted and match the input set";
 
   for (std::size_t pick = 0; pick < actualKeys.size(); ++pick) {
     const int selectedKey = actualKeys[pick];
-    result.set_used_in_simulation(selectedKey);
-    EXPECT_TRUE(result.has_selected_candidate())
+    result.set_chosen_calibration_id(selectedKey);
+    EXPECT_TRUE(result.has_selected_calibration_id())
         << "pick=" << pick << " -> key=" << selectedKey << " should be a valid candidate";
     EXPECT_NO_THROW({
-      const auto &selected_candidate = result.get_selected_candidate();
+      const auto &selected_candidate = result.get_selected_calibration_id();
       (void)selected_candidate;
     });
   }
 
-  result.set_used_in_simulation(99);
-  EXPECT_FALSE(result.has_selected_candidate());
+  result.set_chosen_calibration_id(99);
+  EXPECT_FALSE(result.has_selected_calibration_id());
 }
 
 // Genotype override keys: both absent in YAML means neither key is present in map
 TEST_F(ImmuneSystemParameterOverridesTest, GenotypeKeysAbsentWhenNotInYaml) {
-  auto node = make_candidates_node(0);
+  auto node = make_calibration_ids_node(0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_FALSE(c.has(P::K_MUTATION_PROB))
         << "candidate[" << idx << "] should not have mutation_probability_per_locus key";
     EXPECT_FALSE(c.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER))
@@ -293,11 +293,11 @@ TEST_F(ImmuneSystemParameterOverridesTest, GenotypeKeysAbsentWhenNotInYaml) {
 
 // mutation_probability_per_locus: explicit -1 in YAML is present in map with value -1
 TEST_F(ImmuneSystemParameterOverridesTest, MutationProbExplicitMinusOneIsPreserved) {
-  auto node = make_candidates_node(0, false, /*include_mutation_prob=*/true, /*mutation_prob=*/-1.0);
+  auto node = make_calibration_ids_node(0, false, /*include_mutation_prob=*/true, /*mutation_prob=*/-1.0);
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  for (const auto &[idx, c] : result.get_candidates()) {
+  for (const auto &[idx, c] : result.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB))
         << "candidate[" << idx << "] should have mutation_probability_per_locus key";
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), -1.0)
@@ -308,12 +308,12 @@ TEST_F(ImmuneSystemParameterOverridesTest, MutationProbExplicitMinusOneIsPreserv
 // mutation_probability_per_locus: positive value is parsed and round-trips
 TEST_F(ImmuneSystemParameterOverridesTest, MutationProbPositiveValueRoundtrip) {
   const double inputMutProb = 0.005;
-  auto node = make_candidates_node(0, false, /*include_mutation_prob=*/true, inputMutProb);
+  auto node = make_calibration_ids_node(0, false, /*include_mutation_prob=*/true, inputMutProb);
 
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
-  for (const auto &[idx, c] : original.get_candidates()) {
+  for (const auto &[idx, c] : original.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_MUTATION_PROB));
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), inputMutProb)
         << "candidate[" << idx << "] should have mutation_probability_per_locus=" << inputMutProb;
@@ -323,23 +323,23 @@ TEST_F(ImmuneSystemParameterOverridesTest, MutationProbPositiveValueRoundtrip) {
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  for (const auto &[idx, c] : decoded.get_candidates()) {
+  for (const auto &[idx, c] : decoded.get_calibration_ids()) {
     EXPECT_DOUBLE_EQ(c.get(P::K_MUTATION_PROB, 0.0), inputMutProb)
         << "round-tripped candidate[" << idx << "] should preserve mutation_probability_per_locus";
   }
 }
 
-// default_cnv_reversion_multiplier: zero value (as in most candidates in input.yml) is parsed and round-trips
+// default_cnv_reversion_multiplier: zero value (as in most calibration_ids in input.yml) is parsed and round-trips
 TEST_F(ImmuneSystemParameterOverridesTest, CnvReversionMultiplierZeroRoundtrip) {
   const double inputCnvMult = 0.0;
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/false, -1.0,
                                    /*include_cnv_mult=*/true, inputCnvMult);
 
   ImmuneSystemParameterOverrides original;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, original);
 
-  for (const auto &[idx, c] : original.get_candidates()) {
+  for (const auto &[idx, c] : original.get_calibration_ids()) {
     EXPECT_TRUE(c.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
     EXPECT_DOUBLE_EQ(c.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), inputCnvMult)
         << "candidate[" << idx << "] default_cnv_reversion_multiplier should be 0.0";
@@ -349,7 +349,7 @@ TEST_F(ImmuneSystemParameterOverridesTest, CnvReversionMultiplierZeroRoundtrip) 
   ImmuneSystemParameterOverrides decoded;
   EXPECT_NO_THROW(YAML::convert<ImmuneSystemParameterOverrides>::decode(encoded, decoded));
 
-  for (const auto &[idx, c] : decoded.get_candidates()) {
+  for (const auto &[idx, c] : decoded.get_calibration_ids()) {
     EXPECT_DOUBLE_EQ(c.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), inputCnvMult)
         << "round-tripped candidate[" << idx << "] should preserve default_cnv_reversion_multiplier";
   }
@@ -357,14 +357,14 @@ TEST_F(ImmuneSystemParameterOverridesTest, CnvReversionMultiplierZeroRoundtrip) 
 
 // default_cnv_reversion_multiplier: non-zero value (as in candidate 0 of input.yml) is parsed correctly
 TEST_F(ImmuneSystemParameterOverridesTest, CnvReversionMultiplierNonZeroValue) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true,  /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,       /*cnv_mult=*/0.1);
 
   ImmuneSystemParameterOverrides result;
   YAML::convert<ImmuneSystemParameterOverrides>::decode(node, result);
 
-  const auto &c0 = result.get_candidates().at(0);
+  const auto &c0 = result.get_calibration_ids().at(0);
   EXPECT_TRUE(c0.has(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER));
   EXPECT_DOUBLE_EQ(c0.get(P::K_DEFAULT_CNV_REVERSION_MULTIPLIER, -1.0), 0.1);
   EXPECT_TRUE(c0.has(P::K_MUTATION_PROB));
@@ -373,7 +373,7 @@ TEST_F(ImmuneSystemParameterOverridesTest, CnvReversionMultiplierNonZeroValue) {
 
 // log_all does not crash (smoke test)
 TEST_F(ImmuneSystemParameterOverridesTest, LogAllDoesNotCrash) {
-  auto node = make_candidates_node(0, false,
+  auto node = make_calibration_ids_node(0, false,
                                    /*include_mutation_prob=*/true,  /*mutation_prob=*/0.00085,
                                    /*include_cnv_mult=*/true,       /*cnv_mult=*/0.0);
   ImmuneSystemParameterOverrides result;


### PR DESCRIPTION
1. Change config key name
2. Update memory outout at the end of simulation